### PR TITLE
[codex] support configurable token progress bar brackets

### DIFF
--- a/src/components/tokens.rs
+++ b/src/components/tokens.rs
@@ -326,7 +326,21 @@ impl Component for TokensComponent {
         let mut parts = Vec::new();
 
         if let Some(bar) = self.build_progress_bar(ctx, clamped_percentage) {
-            parts.push(format!("[{bar}]"));
+            let left = self
+                .config
+                .progress_bar_chars
+                .left_bracket
+                .chars()
+                .next()
+                .unwrap_or('[');
+            let right = self
+                .config
+                .progress_bar_chars
+                .right_bracket
+                .chars()
+                .next()
+                .unwrap_or(']');
+            parts.push(format!("{left}{bar}{right}"));
         }
 
         if self.config.show_percentage {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -558,6 +558,10 @@ pub struct TokensProgressBarCharsConfig {
     pub empty: String,
     #[serde(default = "default_backup_char")]
     pub backup: String,
+    #[serde(default = "default_left_bracket")]
+    pub left_bracket: String,
+    #[serde(default = "default_right_bracket")]
+    pub right_bracket: String,
 }
 
 impl Default for TokensProgressBarCharsConfig {
@@ -566,6 +570,8 @@ impl Default for TokensProgressBarCharsConfig {
             filled: default_filled_char(),
             empty: default_empty_char(),
             backup: default_backup_char(),
+            left_bracket: default_left_bracket(),
+            right_bracket: default_right_bracket(),
         }
     }
 }
@@ -1115,6 +1121,14 @@ fn default_empty_char() -> String {
 
 fn default_backup_char() -> String {
     "▓".to_string()
+}
+
+fn default_left_bracket() -> String {
+    "[".to_string()
+}
+
+fn default_right_bracket() -> String {
+    "]".to_string()
 }
 
 fn default_safe_color() -> String {

--- a/src/mock_data.rs
+++ b/src/mock_data.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use claude_code_statusline_pro::core::{CostInfo, InputData, ModelInfo, WorkspaceInfo};
+use serde_json::json;
 
 /// Predefined mock scenarios for CLI preview mode
 pub struct MockDataGenerator {
@@ -57,6 +58,14 @@ fn build_dev_scenario() -> InputData {
             cache_read_tokens: Some(0),
             cache_write_tokens: Some(0),
         }),
+        extra: json!({
+            "__mock__": {
+                "tokensUsage": {
+                    "context_used": 1_840u64,
+                    "context_window": 200_000u64
+                }
+            }
+        }),
         ..Default::default()
     }
 }
@@ -84,6 +93,14 @@ fn build_critical_scenario() -> InputData {
             cache_read_tokens: Some(12_000),
             cache_write_tokens: Some(2_000),
         }),
+        extra: json!({
+            "__mock__": {
+                "tokensUsage": {
+                    "context_used": 125_000u64,
+                    "context_window": 200_000u64
+                }
+            }
+        }),
         ..Default::default()
     }
 }
@@ -106,6 +123,14 @@ fn build_thinking_scenario() -> InputData {
             total_tokens: Some(12_700),
             cache_read_tokens: Some(1_200),
             cache_write_tokens: Some(0),
+        }),
+        extra: json!({
+            "__mock__": {
+                "tokensUsage": {
+                    "context_used": 12_700u64,
+                    "context_window": 200_000u64
+                }
+            }
         }),
         ..Default::default()
     }
@@ -130,6 +155,14 @@ fn build_complete_scenario() -> InputData {
             cache_read_tokens: Some(3_000),
             cache_write_tokens: Some(800),
         }),
+        extra: json!({
+            "__mock__": {
+                "tokensUsage": {
+                    "context_used": 36_000u64,
+                    "context_window": 200_000u64
+                }
+            }
+        }),
         ..Default::default()
     }
 }
@@ -152,6 +185,14 @@ fn build_error_scenario() -> InputData {
             total_tokens: Some(7_000),
             cache_read_tokens: Some(0),
             cache_write_tokens: Some(0),
+        }),
+        extra: json!({
+            "__mock__": {
+                "tokensUsage": {
+                    "context_used": 7_000u64,
+                    "context_window": 200_000u64
+                }
+            }
         }),
         ..Default::default()
     }


### PR DESCRIPTION
## What changed
- added configurable `left_bracket` and `right_bracket` fields to the tokens progress bar schema with `[` and `]` defaults
- updated token rendering to use the configured bracket characters around the generated progress bar
- populated mock preview scenarios with `context_used` and `context_window` values so token usage previews exercise the progress bar consistently

## Why
The tokens widget now supports theme-level control over the progress bar wrapper characters, and the mock scenarios now provide the context usage data needed to preview that output.

## Impact
Users can customize the bracket characters around the token progress bar, and CLI mock previews show realistic token usage context for the updated widget.

## Validation
- `make ci`

## Relate
#50 