### PR TITLE
feat(tui): interactive config editor (ccsp config edit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +40,19 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "ansi-to-tui"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
+dependencies = [
+ "nom",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "anstream"
@@ -159,10 +178,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -267,13 +301,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "claude-code-statusline-pro"
 version = "3.1.4"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
  "criterion",
- "crossterm",
+ "crossterm 0.29.0",
  "dateparser",
  "dialoguer",
  "dirs",
@@ -283,12 +318,13 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "proptest",
+ "ratatui",
  "regex",
  "serde",
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml_edit",
  "ureq",
@@ -301,6 +337,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +358,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -389,6 +439,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -399,7 +465,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -419,6 +485,40 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dateparser"
@@ -685,6 +785,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -813,6 +915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +951,28 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -966,6 +1096,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -998,10 +1134,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1013,6 +1164,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1114,6 +1275,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1313,6 +1480,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,7 +1537,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1406,6 +1594,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1413,7 +1614,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1457,6 +1658,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1617,6 +1824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,10 +1848,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1677,7 +1918,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1689,11 +1930,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1807,10 +2068,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,16 @@ tokio = { version = "1.51", features = [
     "io-util",
 ] }
 
+# TUI editor 的原子保存路径。NamedTempFile::persist 在 Windows 上通过
+# MoveFileEx + MOVEFILE_REPLACE_EXISTING 正确实现"目标文件存在时也能替换"
+# 的 atomic rename 语义;标准库 fs::rename 在 Windows 旧版本 / 部分情况下
+# 无法覆盖已存在文件,会让 `ccsp config edit` 的第二次保存直接失败。
+# (dev-dependencies 里原本也有一份,promoted 过来,自动对 tests 可见。)
+tempfile = "3.27"
+
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }
 pretty_assertions = "1.4"
-tempfile = "3.27"
 proptest = { version = "1.11", default-features = false, features = ["std"] }
 serial_test = "3.4"
 tokio = { version = "1.51", features = ["rt", "macros", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ thiserror = "2.0.18"
 # Terminal handling
 crossterm = "0.29.0"
 
+# TUI config editor (uses its own crossterm 0.28 internally; types accessed via ratatui::crossterm)
+ratatui = "0.29"
+# ANSI → ratatui Line 转换(给 TUI 实时预览上色)
+ansi-to-tui = "7"
+
 # System utilities
 dirs = "6.0.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/components/base.rs
+++ b/src/components/base.rs
@@ -82,6 +82,17 @@ pub struct RenderContext {
     pub config: Arc<Config>,
     /// Terminal capabilities
     pub terminal: TerminalCapabilities,
+    /// 预览模式标记:TUI 编辑器在用 mock data 渲染"这份配置长什么样"。
+    ///
+    /// 非 preview 渲染完全不受影响。preview 时组件必须绕开所有会触碰
+    /// `~/.claude/statusline-pro/...` 的 storage 调用 —— 即便 generator
+    /// 那一层已经跳过了 `ensure_storage_ready` 和 `update_session_snapshot`,
+    /// `UsageComponent` / `TokensComponent` 仍会在 conversation usage 模式下
+    /// 走 `storage::get_*`,底层 `StorageManager::new()` 又会顺手
+    /// `ensure_directories()`,预览就又会在用户真实目录下建文件夹,违反
+    /// "preview 无副作用"的契约。组件看到 `preview_mode = true` 时一律
+    /// 返回占位输出。
+    pub preview_mode: bool,
 }
 
 /// Output from a component

--- a/src/components/branch.rs
+++ b/src/components/branch.rs
@@ -411,6 +411,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         }
     }
 
@@ -464,6 +465,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let output = component.render(&ctx).await;
@@ -502,6 +504,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = BranchComponent::new(config);
@@ -523,6 +526,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = BranchComponent::new(config);
@@ -566,6 +570,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let resolved = BranchComponent::resolve_repo_path(&ctx);

--- a/src/components/model.rs
+++ b/src/components/model.rs
@@ -150,6 +150,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         }
     }
 
@@ -321,6 +322,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = ModelComponent::new(ModelComponentConfig::default());
@@ -370,6 +372,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = ModelComponent::new(ModelComponentConfig::default());
@@ -410,6 +413,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let output = component.render(&ctx).await;

--- a/src/components/project.rs
+++ b/src/components/project.rs
@@ -152,6 +152,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         }
     }
 
@@ -190,6 +191,7 @@ mod tests {
             input: Arc::new(InputData::default()),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let output = component.render(&ctx).await;
@@ -215,6 +217,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = ProjectComponent::new(ProjectComponentConfig::default());
@@ -239,6 +242,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = ProjectComponent::new(ProjectComponentConfig::default());
@@ -263,6 +267,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = ProjectComponent::new(ProjectComponentConfig::default());

--- a/src/components/status.rs
+++ b/src/components/status.rs
@@ -558,6 +558,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         }
     }
 
@@ -628,6 +629,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = StatusComponent::new(StatusComponentConfig::default());
@@ -666,6 +668,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = StatusComponent::new(StatusComponentConfig::default());
@@ -709,6 +712,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let component = StatusComponent::new(config);

--- a/src/components/tokens.rs
+++ b/src/components/tokens.rs
@@ -117,18 +117,25 @@ impl TokensComponent {
             return Some(usage);
         }
 
-        if let Some(session_id) = ctx.input.session_id.as_deref() {
-            if let Ok(Some(tokens)) = storage::get_session_tokens(session_id).await {
-                let used = tokens.input + tokens.cache_creation_input + tokens.cache_read_input;
-                if used == 0 && !self.config.show_zero {
-                    return None;
+        // preview 模式跳过 storage:`storage::get_session_tokens` 底层
+        // `StorageManager::new()` 会 `ensure_directories()`,在用户真实
+        // `~/.claude/statusline-pro/...` 下建目录,违反"preview 无副作用"
+        // 契约。preview 场景下直接落到下面的 show_zero / None 分支即可,
+        // 预览里 token 用量的位置和图标仍然可见,具体数字不需要真实。
+        if !ctx.preview_mode {
+            if let Some(session_id) = ctx.input.session_id.as_deref() {
+                if let Ok(Some(tokens)) = storage::get_session_tokens(session_id).await {
+                    let used = tokens.input + tokens.cache_creation_input + tokens.cache_read_input;
+                    if used == 0 && !self.config.show_zero {
+                        return None;
+                    }
+                    let window = self.context_window_for_model(ctx);
+                    return Some(TokenUsageInfo {
+                        used,
+                        total: window,
+                        percentage: None,
+                    });
                 }
-                let window = self.context_window_for_model(ctx);
-                return Some(TokenUsageInfo {
-                    used,
-                    total: window,
-                    percentage: None,
-                });
             }
         }
         if self.config.show_zero {
@@ -531,6 +538,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         }
     }
 
@@ -657,6 +665,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {
@@ -694,6 +703,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {
@@ -731,6 +741,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {
@@ -761,6 +772,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {
@@ -800,6 +812,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {
@@ -839,6 +852,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {
@@ -882,6 +896,7 @@ mod tests {
             input: Arc::new(input),
             config: Arc::new(Config::default()),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let config = build_tokens_config(|config| {

--- a/src/components/usage.rs
+++ b/src/components/usage.rs
@@ -213,6 +213,18 @@ impl UsageComponent {
     ) -> ComponentOutput {
         let icon = self.select_icon(ctx);
 
+        // preview 模式下绝对不能走真实 storage:`storage::get_conversation_cost_display`
+        // 内部会调 `StorageManager::new()`,其构造会 `ensure_directories()`,
+        // 在用户真实的 `~/.claude/statusline-pro/...` 下建目录,违反"preview
+        // 无副作用"的契约。返回一个稳定的 $0.00 占位,预览里只是让用户能看到
+        // 这个组件会出现在状态行的哪个位置,数字不需要是真实的。
+        if ctx.preview_mode {
+            return ComponentOutput::new("$0.00")
+                .with_icon_color("gray".to_string())
+                .with_text_color("gray".to_string())
+                .with_icon(icon.unwrap_or_default());
+        }
+
         // 使用新的conversation cost API
         match storage::get_conversation_cost_display(session_id).await {
             Ok(cost) => {

--- a/src/core/generator.rs
+++ b/src/core/generator.rs
@@ -45,6 +45,14 @@ pub struct GeneratorOptions {
     pub disable_cache: bool,
     /// Base directory for configuration
     pub config_base_dir: Option<String>,
+    /// Suppress ALL persistent side effects (storage init, session snapshot
+    /// writes, project-id mutation of global state). The TUI config editor
+    /// calls `generate` repeatedly with synthetic mock `InputData` to render
+    /// a preview; without this flag each refresh would write a synthetic
+    /// session snapshot to `~/.claude/.../sessions/mock-*.json`, polluting
+    /// real usage/cost history. When `true`, `generate` skips both
+    /// `ensure_storage_ready` and `update_session_snapshot`.
+    pub preview_mode: bool,
 }
 
 impl Default for GeneratorOptions {
@@ -54,6 +62,7 @@ impl Default for GeneratorOptions {
             update_throttling: true,
             disable_cache: false,
             config_base_dir: None,
+            preview_mode: false,
         }
     }
 }
@@ -87,6 +96,9 @@ pub struct StatuslineGenerator {
     storage_initialized: bool,
     active_project_id: Option<String>,
     config_base_dir: Option<PathBuf>,
+    /// See `GeneratorOptions::preview_mode`: when true, `generate` is
+    /// side-effect free (no storage init, no snapshot persistence).
+    preview_mode: bool,
 }
 
 impl StatuslineGenerator {
@@ -122,6 +134,7 @@ impl StatuslineGenerator {
             storage_initialized: false,
             active_project_id: None,
             config_base_dir,
+            preview_mode: options.preview_mode,
         };
         drop(config_arc);
 
@@ -241,14 +254,22 @@ impl StatuslineGenerator {
     /// Returns an error if component rendering fails or if required
     /// configuration initialization steps cannot complete successfully.
     pub async fn generate(&mut self, input_data: InputData) -> Result<String> {
-        // Check update rate limit
-        self.ensure_storage_ready(&input_data).await?;
+        // Preview mode(TUI 编辑器)完全跳过任何持久化副作用:
+        // 1. `ensure_storage_ready` 会把 mock 的 project_id 注册成全局状态,
+        //    再初始化 storage 子系统,会在 `~/.claude/.../sessions/` 下建目录;
+        // 2. `update_session_snapshot` 会把合成的 mock InputData 落盘成真正的
+        //    session snapshot,污染用户真实的 conversation 使用量/成本数据。
+        // 两者都不是渲染本身必须的,preview 只需要纯粹的 "这份 config 渲染出来
+        // 长什么样",所以直接短路。
+        if !self.preview_mode {
+            self.ensure_storage_ready(&input_data).await?;
 
-        if let Ok(snapshot_value) = serde_json::to_value(&input_data) {
-            if let Err(err) = storage::update_session_snapshot(&snapshot_value).await {
-                // Only log unexpected errors; missing session ID is expected in some scenarios
-                if !err.to_string().contains("No session ID found") {
-                    eprintln!("[statusline] failed to update session snapshot: {err}");
+            if let Ok(snapshot_value) = serde_json::to_value(&input_data) {
+                if let Err(err) = storage::update_session_snapshot(&snapshot_value).await {
+                    // Only log unexpected errors; missing session ID is expected in some scenarios
+                    if !err.to_string().contains("No session ID found") {
+                        eprintln!("[statusline] failed to update session snapshot: {err}");
+                    }
                 }
             }
         }
@@ -490,6 +511,27 @@ mod tests {
         assert_eq!(options.preset, Some("PMBT".to_string()));
         assert!(options.update_throttling);
         assert!(!options.disable_cache);
+        // preview_mode 默认必须 false,否则真实运行的 statusline 也会静默地
+        // 跳过 storage 初始化和 session snapshot 写入,usage/cost 历史就丢了。
+        assert!(!options.preview_mode);
+    }
+
+    /// 回归:`preview_mode=true` 的 generator 不能触碰持久化层。
+    /// 本测试不依赖真实 storage 子系统,只验证字段被如实持有;真正的"不写盘"
+    /// 靠 `generate` 里的 `if !self.preview_mode` 守卫保证,在 `tui::preview`
+    /// 的集成测试里验证。
+    #[test]
+    fn test_generator_preview_mode_is_recorded() {
+        let config = Config::default();
+        let options = GeneratorOptions {
+            preview_mode: true,
+            ..GeneratorOptions::default()
+        };
+        let generator = StatuslineGenerator::new(config, options);
+        assert!(
+            generator.preview_mode,
+            "preview_mode 必须从 options 透传到 generator"
+        );
     }
 
     #[tokio::test]

--- a/src/core/generator.rs
+++ b/src/core/generator.rs
@@ -283,11 +283,16 @@ impl StatuslineGenerator {
         // Detect terminal capabilities
         let capabilities = self.detect_terminal_capabilities();
 
-        // Create render context
+        // Create render context. preview_mode 从 generator 透传到组件,
+        // 让 Usage/Tokens 这种依赖 storage 的组件能跳过 storage 调用 ——
+        // 否则就算 generator 这层已经不写 session snapshot,组件里
+        // `storage::get_*` 的 `StorageManager::new()` 仍会在用户真实目录
+        // 下 `ensure_directories()`,一样算副作用。
         let context = RenderContext {
             input: Arc::new(input_data),
             config: self.config.clone(),
             terminal: capabilities,
+            preview_mode: self.preview_mode,
         };
 
         // Render components

--- a/src/core/multiline.rs
+++ b/src/core/multiline.rs
@@ -1331,6 +1331,7 @@ content = "Hello"
                 supports_emoji: true,
                 supports_nerd_font: false,
             },
+            preview_mode: false,
         };
 
         let result = renderer.render_extension_lines(&context).await;
@@ -1383,6 +1384,7 @@ method = "GET"
             input: Arc::new(InputData::default()),
             config: Arc::new(config),
             terminal: TerminalCapabilities::default(),
+            preview_mode: false,
         };
 
         let result = renderer.render_extension_lines(&context).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use dialoguer::Confirm;
 use toml_edit::{Array, DocumentMut, Item, Table, Value as TomlEditValue};
 
 mod mock_data;
+mod tui;
 use mock_data::MockDataGenerator;
 
 #[derive(Parser, Debug)]
@@ -124,6 +125,23 @@ enum ConfigAction {
     Set(ConfigSetArgs),
     /// 初始化配置文件
     Init(ConfigInitArgs),
+    /// 启动 TUI 配置编辑器
+    Edit(ConfigEditArgs),
+}
+
+#[derive(ClapArgs, Debug, Default)]
+struct ConfigEditArgs {
+    /// 编辑用户级配置(默认优先项目级,无项目级回退到用户级)
+    #[arg(short = 'g', long = "global", action = clap::ArgAction::SetTrue)]
+    global: bool,
+
+    /// 指定配置文件路径(覆盖 --global)
+    #[arg(short = 'f', long = "file")]
+    file: Option<String>,
+
+    /// 预览使用的 mock 场景(dev / critical / thinking / complete / error)
+    #[arg(long = "mock", default_value = "dev")]
+    mock: String,
 }
 
 #[derive(ClapArgs, Debug)]
@@ -284,6 +302,10 @@ async fn handle_config(args: &ConfigArgs) -> Result<()> {
             }
             ConfigAction::Init(init_args) => {
                 handle_config_init(&mut loader, args, init_args)?;
+                return Ok(());
+            }
+            ConfigAction::Edit(edit_args) => {
+                handle_config_edit(&mut loader, args, edit_args).await?;
                 return Ok(());
             }
         }
@@ -463,6 +485,47 @@ fn handle_config_init(
     }
 
     Ok(())
+}
+
+async fn handle_config_edit(
+    loader: &mut ConfigLoader,
+    parent_args: &ConfigArgs,
+    edit_args: &ConfigEditArgs,
+) -> Result<()> {
+    let explicit = parent_args
+        .file
+        .as_deref()
+        .or(edit_args.file.as_deref())
+        .map(PathBuf::from);
+
+    let want_global = edit_args.global || parent_args.global;
+
+    let (path, scope) = if let Some(custom) = explicit {
+        (custom, tui::EditScope::Custom)
+    } else if want_global {
+        let user = loader
+            .user_config_path()
+            .ok_or_else(|| anyhow!("无法确定用户级配置路径"))?;
+        (user, tui::EditScope::User)
+    } else {
+        match loader.project_config_path() {
+            Ok(p) => (p, tui::EditScope::Project),
+            Err(_) => {
+                let user = loader
+                    .user_config_path()
+                    .ok_or_else(|| anyhow!("无法确定用户级配置路径"))?;
+                (user, tui::EditScope::User)
+            }
+        }
+    };
+
+    let options = tui::EditOptions {
+        path,
+        scope,
+        mock_scenario: edit_args.mock.clone(),
+    };
+
+    tui::run(options).await
 }
 
 fn handle_config_set(

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,14 +508,17 @@ async fn handle_config_edit(
             .ok_or_else(|| anyhow!("无法确定用户级配置路径"))?;
         (user, tui::EditScope::User)
     } else {
-        match loader.project_config_path() {
-            Ok(p) => (p, tui::EditScope::Project),
-            Err(_) => {
-                let user = loader
-                    .user_config_path()
-                    .ok_or_else(|| anyhow!("无法确定用户级配置路径"))?;
-                (user, tui::EditScope::User)
-            }
+        // 只有在项目级配置文件实际存在时,才默认进入 Project scope。
+        // `project_config_path()` 即使没有文件也会算出一个路径,直接用会让
+        // 任意目录下的 `config edit` 意外创建项目级 config。
+        let project_existing = loader.project_config_path().ok().filter(|p| p.exists());
+        if let Some(p) = project_existing {
+            (p, tui::EditScope::Project)
+        } else {
+            let user = loader
+                .user_config_path()
+                .ok_or_else(|| anyhow!("无法确定用户级配置路径"))?;
+            (user, tui::EditScope::User)
         }
     };
 

--- a/src/themes/capsule.rs
+++ b/src/themes/capsule.rs
@@ -229,6 +229,7 @@ mod tests {
         RenderContext {
             input: Arc::new(InputData::default()),
             config: Arc::new(config),
+            preview_mode: false,
             terminal: TerminalCapabilities {
                 color_support: if colors {
                     ColorSupport::TrueColor

--- a/src/themes/classic.rs
+++ b/src/themes/classic.rs
@@ -132,6 +132,7 @@ mod tests {
         RenderContext {
             input: Arc::new(InputData::default()),
             config: Arc::new(config),
+            preview_mode: false,
             terminal: TerminalCapabilities {
                 color_support: ColorSupport::None,
                 ..Default::default()
@@ -198,6 +199,7 @@ mod tests {
         let ctx = RenderContext {
             input: Arc::new(InputData::default()),
             config: Arc::new(config),
+            preview_mode: false,
             terminal: TerminalCapabilities {
                 color_support: ColorSupport::None,
                 ..Default::default()

--- a/src/themes/powerline.rs
+++ b/src/themes/powerline.rs
@@ -285,6 +285,7 @@ mod tests {
         RenderContext {
             input: Arc::new(InputData::default()),
             config: Arc::new(config),
+            preview_mode: false,
             terminal: TerminalCapabilities {
                 color_support: if colors {
                     ColorSupport::TrueColor

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -817,6 +817,11 @@ impl App {
     fn error(&mut self, msg: String) {
         self.message = Some((msg, MessageKind::Error));
     }
+
+    /// 对外可见的错误提示。供 event 层等外部模块在拒绝操作时使用。
+    pub fn notify_error(&mut self, msg: impl Into<String>) {
+        self.error(msg.into());
+    }
 }
 
 /// 用一个"干净"的 `ConfigLoader` 解析一次配置,拿合并报告。失败时返回 None。

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use ratatui::text::Line;
 use toml_edit::DocumentMut;
 
-use claude_code_statusline_pro::config::{ConfigLoader, MergeReport};
+use claude_code_statusline_pro::config::{Config, ConfigLoader, MergeReport};
 
 use crate::tui::io;
 use crate::tui::preview;
@@ -205,6 +205,11 @@ pub struct App {
     pub merge_report_visible: bool,
     pub search: Option<SearchState>,
     pub widget_new: Option<NewWidgetDialog>,
+    /// 预览和校验的基线层级。编辑的当前文件之下的所有层(default / user /
+    /// project)按真实 `ConfigLoader` 的合并顺序叠好,作为 `parse_config` 的
+    /// inherited 参数传入。scope 切换时必须一起更新,否则 P1 回归:
+    /// "项目级配置预览丢掉用户层设置"就会复现。
+    pub inherited_json: serde_json::Value,
 }
 
 impl App {
@@ -221,6 +226,10 @@ impl App {
         let widget_summaries = scan_summaries(options.path.parent());
         let widget_files = widgets::scan_files(options.path.parent());
         let merge_report = load_merge_report(&options).await;
+        // inherited_json 必须在 App 构造前算出来:refresh_preview / save 校验
+        // 都要拿它当 parse_config 的 baseline。失败就 graceful-degrade 到
+        // 纯 default,TUI 仍然可用,不会因为一条坏配置打不开编辑器。
+        let inherited_json = compute_inherited_json(&options).await;
 
         let mut app = Self {
             options,
@@ -244,6 +253,7 @@ impl App {
             merge_report_visible: false,
             search: None,
             widget_new: None,
+            inherited_json,
         };
 
         app.refresh_preview().await;
@@ -575,7 +585,15 @@ impl App {
         match field.kind {
             FieldKind::Bool => {
                 let path = field.path;
-                let current = io::get_bool(&self.document, path).unwrap_or(false);
+                // 关键:取"最终生效值"而不是"buffer 里显式写了什么"。
+                // 之前用 io::get_bool(buffer).unwrap_or(false),当 buffer
+                // 没写这个 key 而 default/inherited 是 true 时,会误读成
+                // false,按一次空格写进去 true,等于没变;用户要按两次才
+                // 真的能把默认开启的开关关掉。现在先合并 inherited+buffer
+                // 再取,和运行时一致。
+                let current =
+                    preview::effective_bool(&self.document, &self.inherited_json, path)
+                        .unwrap_or(false);
                 match io::set_bool(&mut self.document, path, !current) {
                     Ok(()) => {
                         self.dirty = true;
@@ -755,8 +773,13 @@ impl App {
         // widget_summaries 只是旧字段帮助面板展示用的别名。
         self.widget_files = widgets::scan_files(target_path.parent());
         self.widget_summaries = scan_summaries(target_path.parent());
-        // 合并报告也是按旧 scope 算的,切 scope 后要重新按新目标算一次
+        // 合并报告也是按旧 scope 算的,切 scope 后要重新按新目标算一次。
+        // inherited_json 同理:新 scope 之下的层完全不一样
+        // (user→空,project→只有 user,custom→user+project),refresh_preview
+        // 必须拿到新的 baseline,否则 P1 回归:切到项目级后 preview 还按用户级
+        // 的 baseline 算 "inherited+buffer",等于多叠了一层用户配置。
         self.merge_report = load_merge_report(&self.options).await;
+        self.inherited_json = compute_inherited_json(&self.options).await;
         self.refresh_preview().await;
         let label = match target_scope {
             EditScope::User => "用户级",
@@ -768,7 +791,7 @@ impl App {
 
     pub async fn save(&mut self) -> Result<()> {
         let doc_str = self.document.to_string();
-        if let Err(err) = preview::parse_config(&doc_str) {
+        if let Err(err) = preview::parse_config(&doc_str, &self.inherited_json) {
             self.error(format!("校验失败,未保存: {err}"));
             return Ok(());
         }
@@ -789,7 +812,7 @@ impl App {
     /// 重新渲染预览。解析失败时优雅降级为提示文案。
     pub async fn refresh_preview(&mut self) {
         let doc_str = self.document.to_string();
-        let config = match preview::parse_config(&doc_str) {
+        let config = match preview::parse_config(&doc_str, &self.inherited_json) {
             Ok(cfg) => cfg,
             Err(err) => {
                 self.preview_lines = vec![Line::from(format!("(预览暂不可用: {err})"))];
@@ -878,6 +901,66 @@ async fn load_merge_report(options: &EditOptions) -> Option<MergeReport> {
     loader.merge_report().cloned()
 }
 
+/// 为"正在编辑的那一层"算出 inherited baseline(= 它之下的所有层合并后的值)。
+///
+/// 这是 Codex round 7 / P1 的核心修复:之前预览永远从 `Config::default()`
+/// 开始叠当前 buffer,等于丢光了用户层 / 项目层之前已经写好的东西。现在按
+/// scope 走和 `ConfigLoader` 一致的层级链,保证预览结果和真实运行时一致。
+///
+/// 失败时不让编辑器开不起来,所以兜底返回 `Config::default()` 的 JSON:
+/// - User 层文件读失败 → 继续;
+/// - ConfigLoader 加载失败 → 继续(Custom scope);
+/// - 最兜底的 `serde_json::to_value(Config::default())` 理论不会失败,
+///   真失败了就给 `Value::Null`,preview 后面会优雅降级成错误提示。
+async fn compute_inherited_json(options: &EditOptions) -> serde_json::Value {
+    match try_compute_inherited(options).await {
+        Ok(v) => v,
+        Err(_) => {
+            serde_json::to_value(Config::default()).unwrap_or(serde_json::Value::Null)
+        }
+    }
+}
+
+async fn try_compute_inherited(options: &EditOptions) -> Result<serde_json::Value> {
+    let mut merged = serde_json::to_value(Config::default())
+        .map_err(|err| anyhow!("序列化默认配置失败: {err}"))?;
+
+    match options.scope {
+        EditScope::User => {
+            // User 是最低的用户可写层,下面就只有 Config::default()。
+        }
+        EditScope::Project => {
+            // Project 之下是 user;直接读用户文件,按稀疏 overlay 叠。
+            // 这里故意不经 ConfigLoader — loader 会同时拉起 project 层本身,
+            // 把我们正在编辑的那份文件也叠进来,得到的就不是"baseline"了。
+            let loader = ConfigLoader::new();
+            if let Some(user_path) = loader.user_config_path() {
+                if user_path.exists() {
+                    let text = std::fs::read_to_string(&user_path)
+                        .map_err(|err| anyhow!("读取用户配置 {} 失败: {err}", user_path.display()))?;
+                    if !text.trim().is_empty() {
+                        let overlay: serde_json::Value = toml_edit::de::from_str(&text)
+                            .map_err(|err| anyhow!("解析用户配置失败: {err}"))?;
+                        preview::merge_json(&mut merged, overlay);
+                    }
+                }
+            }
+        }
+        EditScope::Custom => {
+            // Custom 之下是 default+user+project;`ConfigLoader::load(None)`
+            // 就是这条链的完整合并结果,直接拿来当 baseline 用。
+            let mut loader = ConfigLoader::new();
+            let cfg = loader
+                .load(None)
+                .await
+                .map_err(|err| anyhow!("加载 default+user+project 层失败: {err}"))?;
+            merged = serde_json::to_value(cfg)
+                .map_err(|err| anyhow!("序列化基础配置失败: {err}"))?;
+        }
+    }
+    Ok(merged)
+}
+
 #[cfg(test)]
 mod edit_buffer_tests {
     use super::EditBuffer;
@@ -953,6 +1036,43 @@ mod edit_buffer_tests {
         buf.move_left();
         buf.insert_char('日');
         assert_eq!(buf.text, "中日英");
+    }
+}
+
+#[cfg(test)]
+mod inherited_tests {
+    use super::*;
+
+    /// User scope 之下没有任何层,compute_inherited_json 必须返回纯
+    /// `Config::default()` 的 JSON,等价于旧行为 — 这个 case 是保证
+    /// P1 修复不会破坏 user scope 的既有语义。
+    #[tokio::test]
+    async fn test_compute_inherited_user_scope_returns_defaults() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let options = EditOptions {
+            path: temp.path().join("config.toml"),
+            scope: EditScope::User,
+            mock_scenario: "dev".into(),
+        };
+        let got = compute_inherited_json(&options).await;
+        let defaults = serde_json::to_value(Config::default()).expect("serialize defaults");
+        assert_eq!(got, defaults);
+    }
+
+    /// 兜底逻辑:所有 scope 在输入目录完全不存在等异常路径下,也至少
+    /// 能返回一个可序列化回 Config 的 JSON,不让 TUI 崩。
+    #[tokio::test]
+    async fn test_compute_inherited_degrades_to_defaults_on_missing_dirs() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Custom scope 下即使 path 指向一个完全不存在的地方,也不能 panic
+        let options = EditOptions {
+            path: temp.path().join("definitely_missing/config.toml"),
+            scope: EditScope::Custom,
+            mock_scenario: "dev".into(),
+        };
+        let got = compute_inherited_json(&options).await;
+        // 至少能回转成 Config,不是 Null
+        let _roundtrip: Config = serde_json::from_value(got).expect("inherited must deserialize");
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -611,9 +611,22 @@ impl App {
         if options.is_empty() {
             return;
         }
-        let current = io::get_string(&self.document, path).unwrap_or_default();
+        // 和 bool 切换同样的修复思路:当前值要从"生效值"开始算,而不是只看
+        // buffer 里有没有显式写过。举例:用户层 `theme = "powerline"`,项目
+        // buffer 没提 theme,以前 get_string(buffer).unwrap_or_default() 读到 "",
+        // 找不到匹配就回 index 0,"下一个"等于把 theme 强制写成 options[0]
+        // (即 "classic"),相当于倒退;现在从 powerline 起跳,下一个是 "capsule",
+        // 行为和 bool toggle 以及用户的心智模型一致。Color 也复用这条路径。
+        let current = preview::effective_string(&self.document, &self.inherited_json, path)
+            .unwrap_or_default();
         let idx = options.iter().position(|o| *o == current).unwrap_or(0);
-        let next = (idx + 1) % options.len();
+        // 匹配到时 +1,未匹配(包括 current 为空)时从 0 起步 —— 保留了旧行为
+        // 里"没设过就从第一个开始"的语义,同时不会再把 inherited 的值往回拽。
+        let next = if options.iter().any(|o| *o == current) {
+            (idx + 1) % options.len()
+        } else {
+            0
+        };
         match io::set_string(&mut self.document, path, options[next]) {
             Ok(()) => {
                 self.dirty = true;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -219,7 +219,7 @@ impl App {
             .unwrap_or(0);
         let widget_summaries = scan_summaries(options.path.parent());
         let widget_files = widgets::scan_files(options.path.parent());
-        let merge_report = load_merge_report().await;
+        let merge_report = load_merge_report(&options).await;
 
         let mut app = Self {
             options,
@@ -751,6 +751,8 @@ impl App {
         // widget_summaries 只是旧字段帮助面板展示用的别名。
         self.widget_files = widgets::scan_files(target_path.parent());
         self.widget_summaries = scan_summaries(target_path.parent());
+        // 合并报告也是按旧 scope 算的,切 scope 后要重新按新目标算一次
+        self.merge_report = load_merge_report(&self.options).await;
         self.refresh_preview().await;
         let label = match target_scope {
             EditScope::User => "用户级",
@@ -825,10 +827,18 @@ impl App {
     }
 }
 
-/// 用一个"干净"的 `ConfigLoader` 解析一次配置,拿合并报告。失败时返回 None。
-async fn load_merge_report() -> Option<MergeReport> {
+/// 按当前编辑目标解析一次合并报告。
+///
+/// - `Custom` scope:把文件当成 custom 层顶在 default→user→project 之上;
+/// - `User` / `Project` scope:仍用 `None`,让 loader 从当前 cwd 走完整层级
+///   链,这样报告反映的就是该文件在真实运行时会落在哪一层、会被谁覆盖。
+async fn load_merge_report(options: &EditOptions) -> Option<MergeReport> {
     let mut loader = ConfigLoader::new();
-    loader.load(None).await.ok()?;
+    let custom = match options.scope {
+        EditScope::Custom => Some(options.path.to_string_lossy().into_owned()),
+        EditScope::User | EditScope::Project => None,
+    };
+    loader.load(custom.as_deref()).await.ok()?;
     loader.merge_report().cloned()
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -745,7 +745,11 @@ impl App {
         self.original = new_document;
         self.section_idx = 0;
         self.field_idx = 0;
+        self.widget_cursor = 0;
         self.dirty = false;
+        // Widgets Tab 读的是 widget_files,scope 切换后必须一起刷新;
+        // widget_summaries 只是旧字段帮助面板展示用的别名。
+        self.widget_files = widgets::scan_files(target_path.parent());
         self.widget_summaries = scan_summaries(target_path.parent());
         self.refresh_preview().await;
         let label = match target_scope {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -213,10 +213,11 @@ impl App {
         let document = io::load_or_create(&options.path)?;
         let original = document.clone();
         let mocks = preview::available_mocks();
-        let mock_idx = mocks
-            .iter()
-            .position(|name| name == &options.mock_scenario)
-            .unwrap_or(0);
+        // --mock 写错名字时不能静默用 index 0(排序后可能不是 dev,
+        // 会让用户看到一个和自己输入完全无关的预览场景)。先尝试匹配
+        // 用户输入,匹配不到再回退到文档里承诺的默认 `dev`,同时
+        // 攒一条错误提示,等 App 建好后推到 message 区让用户能看见。
+        let (mock_idx, mock_warning) = resolve_mock_idx(&mocks, &options.mock_scenario);
         let widget_summaries = scan_summaries(options.path.parent());
         let widget_files = widgets::scan_files(options.path.parent());
         let merge_report = load_merge_report(&options).await;
@@ -246,6 +247,9 @@ impl App {
         };
 
         app.refresh_preview().await;
+        if let Some(msg) = mock_warning {
+            app.error(msg);
+        }
         Ok(app)
     }
 
@@ -762,7 +766,7 @@ impl App {
         self.success(format!("已切到 {label}: {}", target_path.display()));
     }
 
-    pub fn save(&mut self) -> Result<()> {
+    pub async fn save(&mut self) -> Result<()> {
         let doc_str = self.document.to_string();
         if let Err(err) = preview::parse_config(&doc_str) {
             self.error(format!("校验失败,未保存: {err}"));
@@ -772,6 +776,10 @@ impl App {
             .with_context(|| format!("保存到 {} 失败", self.options.path.display()))?;
         self.original = self.document.clone();
         self.dirty = false;
+        // 保存后磁盘上合并结果已经变了,F2 overlay 必须重算一次;
+        // 否则用户刚写入的 override 还会留在 added_keys / updated_keys
+        // 里,显示的是"保存前会变成什么",和当前真实文件不一致。
+        self.merge_report = load_merge_report(&self.options).await;
         self.success(format!("已保存 {}", self.options.path.display()));
         Ok(())
     }
@@ -825,6 +833,34 @@ impl App {
     pub fn notify_error(&mut self, msg: impl Into<String>) {
         self.error(msg.into());
     }
+}
+
+/// `--mock` 默认场景,和 `ConfigEditArgs::mock` 的 `default_value` 对齐。
+const DEFAULT_MOCK: &str = "dev";
+
+/// 把用户传进来的 mock 名字解析成 `mocks` 里的索引。
+///
+/// - 命中就直接返回该索引,无警告。
+/// - 没命中就回落到 `dev`(文档承诺的默认场景);同时返回一段中文提示,
+///   让调用方在 App 建好后推到 message 区。回落到 index 0 是之前的行为,
+///   问题是 `mocks` 排序后 index 0 不一定是 `dev`,会让用户看到一个和
+///   自己输入完全无关的预览场景,还以为 TUI 真的支持那个名字。
+fn resolve_mock_idx(mocks: &[String], requested: &str) -> (usize, Option<String>) {
+    if let Some(idx) = mocks.iter().position(|n| n == requested) {
+        return (idx, None);
+    }
+    let fallback_idx = mocks.iter().position(|n| n == DEFAULT_MOCK).unwrap_or(0);
+    let fallback_name = mocks
+        .get(fallback_idx)
+        .map(String::as_str)
+        .unwrap_or(DEFAULT_MOCK);
+    let available = mocks.join(", ");
+    (
+        fallback_idx,
+        Some(format!(
+            "未知 mock 场景 '{requested}',已回落到 '{fallback_name}'。可用:{available}"
+        )),
+    )
 }
 
 /// 按当前编辑目标解析一次合并报告。
@@ -917,5 +953,53 @@ mod edit_buffer_tests {
         buf.move_left();
         buf.insert_char('日');
         assert_eq!(buf.text, "中日英");
+    }
+}
+
+#[cfg(test)]
+mod mock_resolver_tests {
+    use super::{resolve_mock_idx, DEFAULT_MOCK};
+
+    fn sample_mocks() -> Vec<String> {
+        // 与 preview::available_mocks 一样按字典序排;故意让 "dev" 不在 0 号位,
+        // 这样才能证明我们回退到的是 "dev",而不是巧合落在 index 0。
+        let mut v = vec![
+            "critical".to_string(),
+            "complete".to_string(),
+            DEFAULT_MOCK.to_string(),
+            "error".to_string(),
+            "thinking".to_string(),
+        ];
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn test_resolves_known_mock_without_warning() {
+        let mocks = sample_mocks();
+        let (idx, warn) = resolve_mock_idx(&mocks, "thinking");
+        assert_eq!(mocks[idx], "thinking");
+        assert!(warn.is_none());
+    }
+
+    #[test]
+    fn test_unknown_mock_falls_back_to_dev_with_warning() {
+        let mocks = sample_mocks();
+        let (idx, warn) = resolve_mock_idx(&mocks, "totally-bogus");
+        // 必须回到 dev,而不是排序后的 index 0(`complete`)
+        assert_eq!(mocks[idx], DEFAULT_MOCK);
+        let warn = warn.expect("未知 mock 必须返回一条提示");
+        assert!(warn.contains("totally-bogus"));
+        assert!(warn.contains(DEFAULT_MOCK));
+    }
+
+    /// 边界:如果 DEFAULT_MOCK 本身都不在列表里(理论上不该发生,
+    /// 但要保证不会 panic),就兜底到 0 号位且仍有提示。
+    #[test]
+    fn test_unknown_mock_with_missing_default() {
+        let mocks = vec!["alpha".to_string(), "beta".to_string()];
+        let (idx, warn) = resolve_mock_idx(&mocks, "unknown");
+        assert_eq!(idx, 0);
+        assert!(warn.is_some());
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -43,7 +43,92 @@ pub enum Focus {
 #[derive(Debug, Clone)]
 pub enum Mode {
     Normal,
-    EditText(String),
+    EditText(EditBuffer),
+}
+
+/// 带光标的文本缓冲。光标位置是 `text` 的字节偏移,始终对齐到 char 边界。
+#[derive(Debug, Clone, Default)]
+pub struct EditBuffer {
+    pub text: String,
+    pub cursor: usize,
+}
+
+impl EditBuffer {
+    pub fn new(initial: String) -> Self {
+        let cursor = initial.len();
+        Self {
+            text: initial,
+            cursor,
+        }
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.text.insert(self.cursor, c);
+        self.cursor += c.len_utf8();
+    }
+
+    pub fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let prev = self.prev_char_boundary();
+        self.text.replace_range(prev..self.cursor, "");
+        self.cursor = prev;
+    }
+
+    pub fn delete_forward(&mut self) {
+        if self.cursor >= self.text.len() {
+            return;
+        }
+        let next = self.next_char_boundary();
+        self.text.replace_range(self.cursor..next, "");
+    }
+
+    pub fn move_left(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        self.cursor = self.prev_char_boundary();
+    }
+
+    pub fn move_right(&mut self) {
+        if self.cursor >= self.text.len() {
+            return;
+        }
+        self.cursor = self.next_char_boundary();
+    }
+
+    pub fn home(&mut self) {
+        self.cursor = 0;
+    }
+
+    pub fn end(&mut self) {
+        self.cursor = self.text.len();
+    }
+
+    /// 光标前的 `text[..cursor]` 部分(用于渲染)。
+    pub fn before_cursor(&self) -> &str {
+        &self.text[..self.cursor]
+    }
+
+    /// 光标处到末尾的 `text[cursor..]` 部分(用于渲染)。
+    pub fn after_cursor(&self) -> &str {
+        &self.text[self.cursor..]
+    }
+
+    fn prev_char_boundary(&self) -> usize {
+        self.text[..self.cursor]
+            .char_indices()
+            .last()
+            .map_or(0, |(i, _)| i)
+    }
+
+    fn next_char_boundary(&self) -> usize {
+        self.text[self.cursor..]
+            .char_indices()
+            .nth(1)
+            .map_or(self.text.len(), |(offset, _)| self.cursor + offset)
+    }
 }
 
 /// 底部 toast 的性质。
@@ -52,6 +137,14 @@ pub enum MessageKind {
     Info,
     Success,
     Error,
+}
+
+/// 按 `n` 在 Widgets Tab 里新增 widget 时的对话框状态。
+#[derive(Debug, Clone)]
+pub struct NewWidgetDialog {
+    pub target_path: PathBuf,
+    pub target_component: String,
+    pub name: EditBuffer,
 }
 
 /// 跨 section 搜索字段时的中间状态。
@@ -111,6 +204,7 @@ pub struct App {
     pub merge_report: Option<MergeReport>,
     pub merge_report_visible: bool,
     pub search: Option<SearchState>,
+    pub widget_new: Option<NewWidgetDialog>,
 }
 
 impl App {
@@ -148,6 +242,7 @@ impl App {
             merge_report,
             merge_report_visible: false,
             search: None,
+            widget_new: None,
         };
 
         app.refresh_preview().await;
@@ -248,6 +343,72 @@ impl App {
                 self.success(format!("已删除 widget: {name}"));
             }
             Err(err) => self.error(format!("删除失败: {err}")),
+        }
+    }
+
+    /// 打开新增 widget 对话框。目标文件默认是光标所在文件;
+    /// 如果没有任何文件则拒绝(需要用户先准备好 components/*.toml)。
+    pub fn widget_open_new_dialog(&mut self) {
+        let Some(file) = self
+            .widget_files
+            .get(
+                self.flat_widgets()
+                    .get(self.widget_cursor)
+                    .map_or(0, |&(fi, _)| fi),
+            )
+            .or_else(|| self.widget_files.first())
+        else {
+            self.error(
+                "尚未检测到任何 components/*.toml;请先 `ccsp config init -w` 准备模板。"
+                    .to_string(),
+            );
+            return;
+        };
+        self.widget_new = Some(NewWidgetDialog {
+            target_path: file.path.clone(),
+            target_component: file.component.clone(),
+            name: EditBuffer::default(),
+        });
+    }
+
+    pub fn widget_close_new_dialog(&mut self) {
+        self.widget_new = None;
+    }
+
+    pub fn widget_new_insert_char(&mut self, c: char) {
+        if let Some(dialog) = self.widget_new.as_mut() {
+            dialog.name.insert_char(c);
+        }
+    }
+
+    pub fn widget_new_backspace(&mut self) {
+        if let Some(dialog) = self.widget_new.as_mut() {
+            dialog.name.backspace();
+        }
+    }
+
+    pub fn widget_new_commit(&mut self) {
+        let Some(dialog) = self.widget_new.take() else {
+            return;
+        };
+        let name = dialog.name.text.trim().to_string();
+        if name.is_empty() {
+            self.error("widget 名字不能为空".to_string());
+            return;
+        }
+        match widgets::create_widget(&dialog.target_path, &name) {
+            Ok(()) => {
+                self.rescan_widgets();
+                // 把光标移到新创建的 widget
+                if let Some(idx) = self.flat_widgets().iter().position(|&(fi, ei)| {
+                    self.widget_files[fi].path == dialog.target_path
+                        && self.widget_files[fi].entries[ei].name == name
+                }) {
+                    self.widget_cursor = idx;
+                }
+                self.success(format!("已创建 widget {}:{name}", dialog.target_component));
+            }
+            Err(err) => self.error(format!("创建失败: {err}")),
         }
     }
 
@@ -379,20 +540,20 @@ impl App {
         };
         match field.kind {
             FieldKind::Text | FieldKind::Color => {
-                let buf = io::get_string(&self.document, field.path).unwrap_or_default();
-                self.mode = Mode::EditText(buf);
+                let initial = io::get_string(&self.document, field.path).unwrap_or_default();
+                self.mode = Mode::EditText(EditBuffer::new(initial));
             }
             FieldKind::Int { .. } => {
-                let buf = io::get_int(&self.document, field.path)
+                let initial = io::get_int(&self.document, field.path)
                     .map(|v| v.to_string())
                     .unwrap_or_default();
-                self.mode = Mode::EditText(buf);
+                self.mode = Mode::EditText(EditBuffer::new(initial));
             }
             FieldKind::Float { .. } => {
-                let buf = io::get_float(&self.document, field.path)
+                let initial = io::get_float(&self.document, field.path)
                     .map(|v| format!("{v}"))
                     .unwrap_or_default();
-                self.mode = Mode::EditText(buf);
+                self.mode = Mode::EditText(EditBuffer::new(initial));
             }
             FieldKind::Bool => self.space_action(),
             FieldKind::Enum(options) => self.cycle_enum(field.path, options),
@@ -441,15 +602,45 @@ impl App {
         }
     }
 
-    pub fn edit_push_char(&mut self, c: char) {
+    pub fn edit_insert_char(&mut self, c: char) {
         if let Mode::EditText(buf) = &mut self.mode {
-            buf.push(c);
+            buf.insert_char(c);
         }
     }
 
     pub fn edit_backspace(&mut self) {
         if let Mode::EditText(buf) = &mut self.mode {
-            buf.pop();
+            buf.backspace();
+        }
+    }
+
+    pub fn edit_delete(&mut self) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.delete_forward();
+        }
+    }
+
+    pub fn edit_move_left(&mut self) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.move_left();
+        }
+    }
+
+    pub fn edit_move_right(&mut self) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.move_right();
+        }
+    }
+
+    pub fn edit_home(&mut self) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.home();
+        }
+    }
+
+    pub fn edit_end(&mut self) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.end();
         }
     }
 
@@ -458,33 +649,34 @@ impl App {
     }
 
     pub fn commit_edit(&mut self) {
-        let buf = match std::mem::replace(&mut self.mode, Mode::Normal) {
+        let buffer = match std::mem::replace(&mut self.mode, Mode::Normal) {
             Mode::EditText(buf) => buf,
             Mode::Normal => return,
         };
+        let text = buffer.text;
         let Some(field) = self.current_field() else {
             return;
         };
 
         let result = match field.kind {
-            FieldKind::Text => io::set_string(&mut self.document, field.path, &buf),
+            FieldKind::Text => io::set_string(&mut self.document, field.path, &text),
             FieldKind::Color => {
-                let trimmed = buf.trim();
+                let trimmed = text.trim();
                 if trimmed.is_empty() {
                     Err(anyhow!("颜色不能为空"))
                 } else {
                     io::set_string(&mut self.document, field.path, trimmed)
                 }
             }
-            FieldKind::Int { min, max } => match buf.trim().parse::<i64>() {
+            FieldKind::Int { min, max } => match text.trim().parse::<i64>() {
                 Ok(n) if n >= min && n <= max => io::set_int(&mut self.document, field.path, n),
                 Ok(_) => Err(anyhow!("值不在范围 [{min}, {max}]")),
-                Err(_) => Err(anyhow!("不是有效整数: {buf}")),
+                Err(_) => Err(anyhow!("不是有效整数: {text}")),
             },
-            FieldKind::Float { min, max } => match buf.trim().parse::<f64>() {
+            FieldKind::Float { min, max } => match text.trim().parse::<f64>() {
                 Ok(n) if n >= min && n <= max => io::set_float(&mut self.document, field.path, n),
                 Ok(_) => Err(anyhow!("值不在范围 [{min}, {max}]")),
-                Err(_) => Err(anyhow!("不是有效浮点数: {buf}")),
+                Err(_) => Err(anyhow!("不是有效浮点数: {text}")),
             },
             FieldKind::Bool | FieldKind::Enum(_) => Ok(()),
         };
@@ -628,4 +820,82 @@ async fn load_merge_report() -> Option<MergeReport> {
     let mut loader = ConfigLoader::new();
     loader.load(None).await.ok()?;
     loader.merge_report().cloned()
+}
+
+#[cfg(test)]
+mod edit_buffer_tests {
+    use super::EditBuffer;
+
+    #[test]
+    fn test_insert_at_end() {
+        let mut buf = EditBuffer::new("hi".to_string());
+        assert_eq!(buf.cursor, 2);
+        buf.insert_char('!');
+        assert_eq!(buf.text, "hi!");
+        assert_eq!(buf.cursor, 3);
+    }
+
+    #[test]
+    fn test_insert_in_middle() {
+        let mut buf = EditBuffer::new("abc".to_string());
+        buf.move_left(); // cursor at index 2 (between 'b' and 'c')
+        buf.insert_char('X');
+        assert_eq!(buf.text, "abXc");
+        assert_eq!(buf.cursor, 3);
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut buf = EditBuffer::new("abc".to_string());
+        buf.backspace();
+        assert_eq!(buf.text, "ab");
+        assert_eq!(buf.cursor, 2);
+    }
+
+    #[test]
+    fn test_backspace_at_start_noop() {
+        let mut buf = EditBuffer::new("a".to_string());
+        buf.home();
+        buf.backspace();
+        assert_eq!(buf.text, "a");
+        assert_eq!(buf.cursor, 0);
+    }
+
+    #[test]
+    fn test_delete_forward() {
+        let mut buf = EditBuffer::new("abc".to_string());
+        buf.home();
+        buf.delete_forward();
+        assert_eq!(buf.text, "bc");
+        assert_eq!(buf.cursor, 0);
+    }
+
+    #[test]
+    fn test_home_end() {
+        let mut buf = EditBuffer::new("abc".to_string());
+        buf.home();
+        assert_eq!(buf.cursor, 0);
+        buf.end();
+        assert_eq!(buf.cursor, 3);
+    }
+
+    #[test]
+    fn test_utf8_handling() {
+        // "α" is 2 bytes in UTF-8
+        let mut buf = EditBuffer::new("αβ".to_string());
+        assert_eq!(buf.cursor, 4);
+        buf.move_left();
+        assert_eq!(buf.cursor, 2);
+        buf.backspace();
+        assert_eq!(buf.text, "β");
+        assert_eq!(buf.cursor, 0);
+    }
+
+    #[test]
+    fn test_chinese_insert() {
+        let mut buf = EditBuffer::new("中英".to_string());
+        buf.move_left();
+        buf.insert_char('日');
+        assert_eq!(buf.text, "中日英");
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,631 @@
+//! TUI 状态机
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use ratatui::text::Line;
+use toml_edit::DocumentMut;
+
+use claude_code_statusline_pro::config::{ConfigLoader, MergeReport};
+
+use crate::tui::io;
+use crate::tui::preview;
+use crate::tui::sections::{Field, FieldKind, Section, COLOR_PALETTE, SECTIONS};
+use crate::tui::widgets::{self, scan_summaries, WidgetFile, WidgetSummary};
+
+/// 编辑目标层级。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditScope {
+    User,
+    Project,
+    Custom,
+}
+
+/// 启动参数。
+#[derive(Debug, Clone)]
+pub struct EditOptions {
+    pub path: PathBuf,
+    pub scope: EditScope,
+    pub mock_scenario: String,
+}
+
+/// 当前焦点区域。v2 会启用 `Tabs` 让用户在 Tab 栏里单独高亮。
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Focus {
+    /// 顶部 Tab 栏
+    Tabs,
+    /// 中部字段列表
+    Fields,
+}
+
+/// 编辑模式:文本输入缓冲。
+#[derive(Debug, Clone)]
+pub enum Mode {
+    Normal,
+    EditText(String),
+}
+
+/// 底部 toast 的性质。
+#[derive(Debug, Clone, Copy)]
+pub enum MessageKind {
+    Info,
+    Success,
+    Error,
+}
+
+/// 跨 section 搜索字段时的中间状态。
+#[derive(Debug, Clone, Default)]
+pub struct SearchState {
+    /// 当前输入的查询串(lowercase 化后匹配)
+    pub query: String,
+    /// 命中的 (section_idx, field_idx) 列表
+    pub results: Vec<(usize, usize)>,
+    /// 结果列表当前选中下标
+    pub selected: usize,
+}
+
+impl SearchState {
+    pub fn recompute(&mut self) {
+        let q = self.query.to_ascii_lowercase();
+        self.results.clear();
+        if q.is_empty() {
+            self.selected = 0;
+            return;
+        }
+        for (si, section) in SECTIONS.iter().enumerate() {
+            for (fi, field) in section.fields.iter().enumerate() {
+                let hay_section = section.title.to_ascii_lowercase();
+                let hay_label = field.label.to_ascii_lowercase();
+                let hay_path = field.path.to_ascii_lowercase();
+                if hay_section.contains(&q) || hay_label.contains(&q) || hay_path.contains(&q) {
+                    self.results.push((si, fi));
+                }
+            }
+        }
+        if self.selected >= self.results.len() {
+            self.selected = self.results.len().saturating_sub(1);
+        }
+    }
+}
+
+pub struct App {
+    pub options: EditOptions,
+    pub document: DocumentMut,
+    pub original: DocumentMut,
+    pub section_idx: usize,
+    pub field_idx: usize,
+    pub focus: Focus,
+    pub mode: Mode,
+    pub mocks: Vec<String>,
+    pub mock_idx: usize,
+    pub preview_lines: Vec<Line<'static>>,
+    pub help_visible: bool,
+    pub message: Option<(String, MessageKind)>,
+    pub dirty: bool,
+    pub should_quit: bool,
+    pub widget_summaries: Vec<WidgetSummary>,
+    pub widget_files: Vec<WidgetFile>,
+    /// Widgets Tab 的光标:扁平索引,见 `flat_widgets`
+    pub widget_cursor: usize,
+    pub merge_report: Option<MergeReport>,
+    pub merge_report_visible: bool,
+    pub search: Option<SearchState>,
+}
+
+impl App {
+    /// 构造并立即尝试生成一次预览。
+    pub async fn from_options(options: EditOptions) -> Result<Self> {
+        let document = io::load_or_create(&options.path)?;
+        let original = document.clone();
+        let mocks = preview::available_mocks();
+        let mock_idx = mocks
+            .iter()
+            .position(|name| name == &options.mock_scenario)
+            .unwrap_or(0);
+        let widget_summaries = scan_summaries(options.path.parent());
+        let widget_files = widgets::scan_files(options.path.parent());
+        let merge_report = load_merge_report().await;
+
+        let mut app = Self {
+            options,
+            document,
+            original,
+            section_idx: 0,
+            field_idx: 0,
+            focus: Focus::Fields,
+            mode: Mode::Normal,
+            mocks,
+            mock_idx,
+            preview_lines: Vec::new(),
+            help_visible: false,
+            message: None,
+            dirty: false,
+            should_quit: false,
+            widget_summaries,
+            widget_files,
+            widget_cursor: 0,
+            merge_report,
+            merge_report_visible: false,
+            search: None,
+        };
+
+        app.refresh_preview().await;
+        Ok(app)
+    }
+
+    pub fn toggle_merge_report(&mut self) {
+        self.merge_report_visible = !self.merge_report_visible;
+    }
+
+    // ---- Widgets Tab ----
+
+    /// 是否当前处于 Widgets 这个特殊 Tab。
+    pub fn is_widgets_tab(&self) -> bool {
+        self.current_section().title == "Widgets"
+    }
+
+    /// 扁平列出所有 widgets,每项返回 (file_idx, entry_idx)。
+    pub fn flat_widgets(&self) -> Vec<(usize, usize)> {
+        let mut out = Vec::new();
+        for (fi, file) in self.widget_files.iter().enumerate() {
+            for ei in 0..file.entries.len() {
+                out.push((fi, ei));
+            }
+        }
+        out
+    }
+
+    pub fn widget_count(&self) -> usize {
+        self.widget_files.iter().map(|f| f.entries.len()).sum()
+    }
+
+    pub fn widget_next(&mut self) {
+        let n = self.widget_count();
+        if n == 0 {
+            return;
+        }
+        self.widget_cursor = (self.widget_cursor + 1) % n;
+    }
+
+    pub fn widget_prev(&mut self) {
+        let n = self.widget_count();
+        if n == 0 {
+            return;
+        }
+        self.widget_cursor = if self.widget_cursor == 0 {
+            n - 1
+        } else {
+            self.widget_cursor - 1
+        };
+    }
+
+    fn current_widget_ref(&self) -> Option<(PathBuf, String)> {
+        let flat = self.flat_widgets();
+        let &(fi, ei) = flat.get(self.widget_cursor)?;
+        let file = self.widget_files.get(fi)?;
+        let entry = file.entries.get(ei)?;
+        Some((file.path.clone(), entry.name.clone()))
+    }
+
+    pub fn widget_toggle_enabled(&mut self) {
+        let Some((path, name)) = self.current_widget_ref() else {
+            return;
+        };
+        match widgets::toggle_enabled(&path, &name) {
+            Ok(new_value) => {
+                self.rescan_widgets();
+                self.success(format!("{name}.enabled = {new_value}"));
+            }
+            Err(err) => self.error(format!("切 enabled 失败: {err}")),
+        }
+    }
+
+    pub fn widget_cycle_type(&mut self) {
+        let Some((path, name)) = self.current_widget_ref() else {
+            return;
+        };
+        match widgets::cycle_type(&path, &name) {
+            Ok(new_type) => {
+                self.rescan_widgets();
+                self.success(format!("{name}.type = {new_type}"));
+            }
+            Err(err) => self.error(format!("切 type 失败: {err}")),
+        }
+    }
+
+    pub fn widget_delete(&mut self) {
+        let Some((path, name)) = self.current_widget_ref() else {
+            return;
+        };
+        match widgets::delete_widget(&path, &name) {
+            Ok(()) => {
+                self.rescan_widgets();
+                let count = self.widget_count();
+                if count > 0 && self.widget_cursor >= count {
+                    self.widget_cursor = count - 1;
+                }
+                self.success(format!("已删除 widget: {name}"));
+            }
+            Err(err) => self.error(format!("删除失败: {err}")),
+        }
+    }
+
+    fn rescan_widgets(&mut self) {
+        self.widget_files = widgets::scan_files(self.options.path.parent());
+        self.widget_summaries = scan_summaries(self.options.path.parent());
+    }
+
+    // ---- 搜索 ----
+
+    pub fn open_search(&mut self) {
+        let mut state = SearchState::default();
+        state.recompute();
+        self.search = Some(state);
+    }
+
+    pub fn close_search(&mut self) {
+        self.search = None;
+    }
+
+    pub fn search_push_char(&mut self, c: char) {
+        if let Some(state) = self.search.as_mut() {
+            state.query.push(c);
+            state.recompute();
+        }
+    }
+
+    pub fn search_backspace(&mut self) {
+        if let Some(state) = self.search.as_mut() {
+            state.query.pop();
+            state.recompute();
+        }
+    }
+
+    pub fn search_move(&mut self, delta: i32) {
+        let Some(state) = self.search.as_mut() else {
+            return;
+        };
+        let len = state.results.len();
+        if len == 0 {
+            return;
+        }
+        let i = state.selected as i32 + delta;
+        let wrapped = i.rem_euclid(len as i32);
+        state.selected = wrapped as usize;
+    }
+
+    /// 回车确认时:跳到对应 section+field,关闭 overlay。
+    pub fn search_commit(&mut self) {
+        let Some(state) = self.search.as_ref() else {
+            return;
+        };
+        if let Some(&(si, fi)) = state.results.get(state.selected) {
+            self.section_idx = si;
+            self.field_idx = fi;
+            self.info(format!(
+                "跳转: {}.{}",
+                SECTIONS[si].title, SECTIONS[si].fields[fi].label
+            ));
+        }
+        self.search = None;
+    }
+
+    pub fn current_section(&self) -> &'static Section {
+        let idx = self.section_idx.min(SECTIONS.len().saturating_sub(1));
+        &SECTIONS[idx]
+    }
+
+    pub fn current_field(&self) -> Option<&'static Field> {
+        self.current_section().fields.get(self.field_idx)
+    }
+
+    pub fn current_mock(&self) -> &str {
+        self.mocks.get(self.mock_idx).map_or("dev", String::as_str)
+    }
+
+    // ---- 导航 ----
+
+    pub fn next_tab(&mut self) {
+        self.section_idx = (self.section_idx + 1) % SECTIONS.len();
+        self.field_idx = 0;
+    }
+
+    pub fn prev_tab(&mut self) {
+        if self.section_idx == 0 {
+            self.section_idx = SECTIONS.len().saturating_sub(1);
+        } else {
+            self.section_idx -= 1;
+        }
+        self.field_idx = 0;
+    }
+
+    pub fn next_field(&mut self) {
+        let len = self.current_section().fields.len();
+        if len == 0 {
+            return;
+        }
+        self.field_idx = (self.field_idx + 1) % len;
+    }
+
+    pub fn prev_field(&mut self) {
+        let len = self.current_section().fields.len();
+        if len == 0 {
+            return;
+        }
+        if self.field_idx == 0 {
+            self.field_idx = len - 1;
+        } else {
+            self.field_idx -= 1;
+        }
+    }
+
+    pub fn cycle_mock(&mut self) {
+        if self.mocks.is_empty() {
+            return;
+        }
+        self.mock_idx = (self.mock_idx + 1) % self.mocks.len();
+    }
+
+    // ---- 编辑 ----
+
+    /// `Enter` 触发:进入当前字段的"主编辑路径"。
+    /// - Text / Int / Float / Color:进入文本输入(Color 支持 hex 等自由输入)
+    /// - Bool:立即翻转
+    /// - Enum:循环下一个
+    pub fn begin_edit(&mut self) {
+        let Some(field) = self.current_field() else {
+            return;
+        };
+        match field.kind {
+            FieldKind::Text | FieldKind::Color => {
+                let buf = io::get_string(&self.document, field.path).unwrap_or_default();
+                self.mode = Mode::EditText(buf);
+            }
+            FieldKind::Int { .. } => {
+                let buf = io::get_int(&self.document, field.path)
+                    .map(|v| v.to_string())
+                    .unwrap_or_default();
+                self.mode = Mode::EditText(buf);
+            }
+            FieldKind::Float { .. } => {
+                let buf = io::get_float(&self.document, field.path)
+                    .map(|v| format!("{v}"))
+                    .unwrap_or_default();
+                self.mode = Mode::EditText(buf);
+            }
+            FieldKind::Bool => self.space_action(),
+            FieldKind::Enum(options) => self.cycle_enum(field.path, options),
+        }
+    }
+
+    /// `Space` 触发:快速切换。
+    /// - Bool:翻转
+    /// - Enum / Color:循环下一个候选
+    /// - 其他类型:无操作
+    pub fn space_action(&mut self) {
+        let Some(field) = self.current_field() else {
+            return;
+        };
+        match field.kind {
+            FieldKind::Bool => {
+                let path = field.path;
+                let current = io::get_bool(&self.document, path).unwrap_or(false);
+                match io::set_bool(&mut self.document, path, !current) {
+                    Ok(()) => {
+                        self.dirty = true;
+                        self.info(format!("{path} = {}", !current));
+                    }
+                    Err(err) => self.error(format!("更新失败: {err}")),
+                }
+            }
+            FieldKind::Enum(options) => self.cycle_enum(field.path, options),
+            FieldKind::Color => self.cycle_enum(field.path, COLOR_PALETTE),
+            FieldKind::Text | FieldKind::Int { .. } | FieldKind::Float { .. } => {}
+        }
+    }
+
+    fn cycle_enum(&mut self, path: &str, options: &[&str]) {
+        if options.is_empty() {
+            return;
+        }
+        let current = io::get_string(&self.document, path).unwrap_or_default();
+        let idx = options.iter().position(|o| *o == current).unwrap_or(0);
+        let next = (idx + 1) % options.len();
+        match io::set_string(&mut self.document, path, options[next]) {
+            Ok(()) => {
+                self.dirty = true;
+                self.info(format!("{path} = {}", options[next]));
+            }
+            Err(err) => self.error(format!("更新失败: {err}")),
+        }
+    }
+
+    pub fn edit_push_char(&mut self, c: char) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.push(c);
+        }
+    }
+
+    pub fn edit_backspace(&mut self) {
+        if let Mode::EditText(buf) = &mut self.mode {
+            buf.pop();
+        }
+    }
+
+    pub fn cancel_edit(&mut self) {
+        self.mode = Mode::Normal;
+    }
+
+    pub fn commit_edit(&mut self) {
+        let buf = match std::mem::replace(&mut self.mode, Mode::Normal) {
+            Mode::EditText(buf) => buf,
+            Mode::Normal => return,
+        };
+        let Some(field) = self.current_field() else {
+            return;
+        };
+
+        let result = match field.kind {
+            FieldKind::Text => io::set_string(&mut self.document, field.path, &buf),
+            FieldKind::Color => {
+                let trimmed = buf.trim();
+                if trimmed.is_empty() {
+                    Err(anyhow!("颜色不能为空"))
+                } else {
+                    io::set_string(&mut self.document, field.path, trimmed)
+                }
+            }
+            FieldKind::Int { min, max } => match buf.trim().parse::<i64>() {
+                Ok(n) if n >= min && n <= max => io::set_int(&mut self.document, field.path, n),
+                Ok(_) => Err(anyhow!("值不在范围 [{min}, {max}]")),
+                Err(_) => Err(anyhow!("不是有效整数: {buf}")),
+            },
+            FieldKind::Float { min, max } => match buf.trim().parse::<f64>() {
+                Ok(n) if n >= min && n <= max => io::set_float(&mut self.document, field.path, n),
+                Ok(_) => Err(anyhow!("值不在范围 [{min}, {max}]")),
+                Err(_) => Err(anyhow!("不是有效浮点数: {buf}")),
+            },
+            FieldKind::Bool | FieldKind::Enum(_) => Ok(()),
+        };
+
+        match result {
+            Ok(()) => {
+                self.dirty = true;
+                self.success(format!("已更新 {}", field.path));
+            }
+            Err(err) => self.error(format!("更新失败: {err}")),
+        }
+    }
+
+    // ---- 保存/撤销/切 scope ----
+
+    pub fn revert(&mut self) {
+        self.document = self.original.clone();
+        self.dirty = false;
+        self.info("已撤销所有未保存修改".to_string());
+    }
+
+    /// 在 user ↔ project 之间切换。`Custom` scope 下不允许切换,需要重新用 CLI 进入。
+    /// 如果当前有未保存修改会拒绝切换,由用户先 Ctrl+S 或 Ctrl+R 清理。
+    pub async fn switch_scope(&mut self) {
+        if self.dirty {
+            self.error("有未保存修改,请先 Ctrl+S 保存或 Ctrl+R 撤销后再切 scope".to_string());
+            return;
+        }
+        if self.options.scope == EditScope::Custom {
+            self.error(
+                "自定义路径下不支持切换 scope。请用 --global 或无参数重新进入。".to_string(),
+            );
+            return;
+        }
+
+        let loader = ConfigLoader::new();
+        let (target_path, target_scope) = match self.options.scope {
+            EditScope::User => match loader.project_config_path() {
+                Ok(p) => (p, EditScope::Project),
+                Err(err) => {
+                    self.error(format!("无法解析项目级路径: {err}"));
+                    return;
+                }
+            },
+            EditScope::Project => match loader.user_config_path() {
+                Some(p) => (p, EditScope::User),
+                None => {
+                    self.error("无法解析用户级路径(home 目录不可访问)".to_string());
+                    return;
+                }
+            },
+            EditScope::Custom => return,
+        };
+
+        let new_document = match io::load_or_create(&target_path) {
+            Ok(doc) => doc,
+            Err(err) => {
+                self.error(format!("加载目标 scope 失败: {err}"));
+                return;
+            }
+        };
+
+        self.options.path = target_path.clone();
+        self.options.scope = target_scope;
+        self.document = new_document.clone();
+        self.original = new_document;
+        self.section_idx = 0;
+        self.field_idx = 0;
+        self.dirty = false;
+        self.widget_summaries = scan_summaries(target_path.parent());
+        self.refresh_preview().await;
+        let label = match target_scope {
+            EditScope::User => "用户级",
+            EditScope::Project => "项目级",
+            EditScope::Custom => "自定义",
+        };
+        self.success(format!("已切到 {label}: {}", target_path.display()));
+    }
+
+    pub fn save(&mut self) -> Result<()> {
+        let doc_str = self.document.to_string();
+        if let Err(err) = preview::parse_config(&doc_str) {
+            self.error(format!("校验失败,未保存: {err}"));
+            return Ok(());
+        }
+        io::save(&self.options.path, &self.document)
+            .with_context(|| format!("保存到 {} 失败", self.options.path.display()))?;
+        self.original = self.document.clone();
+        self.dirty = false;
+        self.success(format!("已保存 {}", self.options.path.display()));
+        Ok(())
+    }
+
+    // ---- 预览 ----
+
+    /// 重新渲染预览。解析失败时优雅降级为提示文案。
+    pub async fn refresh_preview(&mut self) {
+        let doc_str = self.document.to_string();
+        let config = match preview::parse_config(&doc_str) {
+            Ok(cfg) => cfg,
+            Err(err) => {
+                self.preview_lines = vec![Line::from(format!("(预览暂不可用: {err})"))];
+                return;
+            }
+        };
+
+        let scenario = self.current_mock().to_string();
+        match preview::render(&config, &scenario).await {
+            Ok(lines) => self.preview_lines = lines,
+            Err(err) => {
+                self.preview_lines = vec![Line::from(format!("(预览渲染失败: {err})"))];
+            }
+        }
+    }
+
+    // ---- 小工具 ----
+
+    pub fn toggle_help(&mut self) {
+        self.help_visible = !self.help_visible;
+    }
+
+    pub fn request_quit(&mut self) {
+        self.should_quit = true;
+    }
+
+    fn info(&mut self, msg: String) {
+        self.message = Some((msg, MessageKind::Info));
+    }
+
+    fn success(&mut self, msg: String) {
+        self.message = Some((msg, MessageKind::Success));
+    }
+
+    fn error(&mut self, msg: String) {
+        self.message = Some((msg, MessageKind::Error));
+    }
+}
+
+/// 用一个"干净"的 `ConfigLoader` 解析一次配置,拿合并报告。失败时返回 None。
+async fn load_merge_report() -> Option<MergeReport> {
+    let mut loader = ConfigLoader::new();
+    loader.load(None).await.ok()?;
+    loader.merge_report().cloned()
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -591,9 +591,8 @@ impl App {
                 // false,按一次空格写进去 true,等于没变;用户要按两次才
                 // 真的能把默认开启的开关关掉。现在先合并 inherited+buffer
                 // 再取,和运行时一致。
-                let current =
-                    preview::effective_bool(&self.document, &self.inherited_json, path)
-                        .unwrap_or(false);
+                let current = preview::effective_bool(&self.document, &self.inherited_json, path)
+                    .unwrap_or(false);
                 match io::set_bool(&mut self.document, path, !current) {
                     Ok(()) => {
                         self.dirty = true;
@@ -915,9 +914,7 @@ async fn load_merge_report(options: &EditOptions) -> Option<MergeReport> {
 async fn compute_inherited_json(options: &EditOptions) -> serde_json::Value {
     match try_compute_inherited(options).await {
         Ok(v) => v,
-        Err(_) => {
-            serde_json::to_value(Config::default()).unwrap_or(serde_json::Value::Null)
-        }
+        Err(_) => serde_json::to_value(Config::default()).unwrap_or(serde_json::Value::Null),
     }
 }
 
@@ -936,8 +933,9 @@ async fn try_compute_inherited(options: &EditOptions) -> Result<serde_json::Valu
             let loader = ConfigLoader::new();
             if let Some(user_path) = loader.user_config_path() {
                 if user_path.exists() {
-                    let text = std::fs::read_to_string(&user_path)
-                        .map_err(|err| anyhow!("读取用户配置 {} 失败: {err}", user_path.display()))?;
+                    let text = std::fs::read_to_string(&user_path).map_err(|err| {
+                        anyhow!("读取用户配置 {} 失败: {err}", user_path.display())
+                    })?;
                     if !text.trim().is_empty() {
                         let overlay: serde_json::Value = toml_edit::de::from_str(&text)
                             .map_err(|err| anyhow!("解析用户配置失败: {err}"))?;
@@ -954,8 +952,8 @@ async fn try_compute_inherited(options: &EditOptions) -> Result<serde_json::Valu
                 .load(None)
                 .await
                 .map_err(|err| anyhow!("加载 default+user+project 层失败: {err}"))?;
-            merged = serde_json::to_value(cfg)
-                .map_err(|err| anyhow!("序列化基础配置失败: {err}"))?;
+            merged =
+                serde_json::to_value(cfg).map_err(|err| anyhow!("序列化基础配置失败: {err}"))?;
         }
     }
     Ok(merged)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -788,7 +788,8 @@ impl App {
         };
 
         let scenario = self.current_mock().to_string();
-        match preview::render(&config, &scenario).await {
+        let base_dir = self.options.path.parent();
+        match preview::render(&config, &scenario, base_dir).await {
             Ok(lines) => self.preview_lines = lines,
             Err(err) => {
                 self.preview_lines = vec![Line::from(format!("(预览渲染失败: {err})"))];

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -146,6 +146,15 @@ async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
                 app.notify_error("编辑进行中,请先 Enter 提交或 Esc 取消,再 Ctrl+S 保存");
                 return Ok(false);
             }
+            KeyCode::Char('r') => {
+                // 和 Ctrl+S / Ctrl+T 一样:revert 只会重置 document 和 dirty,
+                // 不会清 EditBuffer。如果这里放行,用户会看到"已撤销"的提示,
+                // 然后下一下 Enter 就把旧 buffer 的内容原封不动地写进刚刚
+                // revert 回来的 document,等于"revert 一下反而写进了旧修改"。
+                // 显式 block 并告诉用户怎么操作。
+                app.notify_error("编辑进行中,请先 Enter 提交或 Esc 取消,再 Ctrl+R 撤销");
+                return Ok(false);
+            }
             _ => {}
         }
     }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -55,9 +55,35 @@ async fn handle_key(app: &mut App, key: KeyEvent) -> Result<bool> {
         return Ok(handle_search(app, key));
     }
 
+    if app.widget_new.is_some() {
+        return Ok(handle_widget_new(app, key));
+    }
+
     match &app.mode {
         Mode::Normal => Ok(handle_normal(app, key)),
         Mode::EditText(_) => Ok(handle_edit_text(app, key)),
+    }
+}
+
+fn handle_widget_new(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.widget_close_new_dialog();
+            false
+        }
+        KeyCode::Enter => {
+            app.widget_new_commit();
+            true
+        }
+        KeyCode::Backspace => {
+            app.widget_new_backspace();
+            false
+        }
+        KeyCode::Char(c) => {
+            app.widget_new_insert_char(c);
+            false
+        }
+        _ => false,
     }
 }
 
@@ -92,6 +118,21 @@ fn handle_search(app: &mut App, key: KeyEvent) -> bool {
 }
 
 async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
+    // 文本编辑模式里 Ctrl+A/E 走行首/行尾,不被全局保存等吃掉
+    if matches!(app.mode, Mode::EditText(_)) {
+        match key.code {
+            KeyCode::Char('a') => {
+                app.edit_home();
+                return Ok(false);
+            }
+            KeyCode::Char('e') => {
+                app.edit_end();
+                return Ok(false);
+            }
+            _ => {}
+        }
+    }
+
     match key.code {
         KeyCode::Char('q') => {
             app.request_quit();
@@ -181,6 +222,10 @@ fn handle_widgets_tab(app: &mut App, key: KeyEvent) -> bool {
             app.widget_delete();
             true
         }
+        KeyCode::Char('n') => {
+            app.widget_open_new_dialog();
+            false
+        }
         KeyCode::Char('?') => {
             app.toggle_help();
             false
@@ -198,6 +243,7 @@ fn handle_widgets_tab(app: &mut App, key: KeyEvent) -> bool {
 }
 
 fn handle_edit_text(app: &mut App, key: KeyEvent) -> bool {
+    // Ctrl 组合键已经在外层 handle_ctrl 里处理了;这里只处理普通键。
     match key.code {
         KeyCode::Esc => {
             app.cancel_edit();
@@ -211,8 +257,28 @@ fn handle_edit_text(app: &mut App, key: KeyEvent) -> bool {
             app.edit_backspace();
             false
         }
+        KeyCode::Delete => {
+            app.edit_delete();
+            false
+        }
+        KeyCode::Left => {
+            app.edit_move_left();
+            false
+        }
+        KeyCode::Right => {
+            app.edit_move_right();
+            false
+        }
+        KeyCode::Home => {
+            app.edit_home();
+            false
+        }
+        KeyCode::End => {
+            app.edit_end();
+            false
+        }
         KeyCode::Char(c) => {
-            app.edit_push_char(c);
+            app.edit_insert_char(c);
             false
         }
         _ => false,

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -123,6 +123,11 @@ async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
     // - Ctrl+Q 直接退出(用户放弃编辑,可接受)
     // - Ctrl+T 会改 section_idx/field_idx,把 buffer 指向另一个字段后的
     //   Enter 会把错误内容写进新字段。必须拒绝。
+    // - Ctrl+S 如果直接放行,save() 看到的是 *还没 commit 的 document*;
+    //   写盘后报 "已保存",但用户刚打的字只在 EditBuffer 里,退出就丢了。
+    //   策略和 Ctrl+T 一致:显式报错,不做隐式 commit-then-save(commit
+    //   可能因类型校验失败而回滚 buffer,那时再 save 等于把脏旧 doc 写盘,
+    //   产生"明明提示更新失败却还是保存成功"的矛盾 UX)。
     if matches!(app.mode, Mode::EditText(_)) {
         match key.code {
             KeyCode::Char('a') => {
@@ -135,6 +140,10 @@ async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
             }
             KeyCode::Char('t') => {
                 app.notify_error("编辑进行中,请先 Enter 提交或 Esc 取消,再切 scope");
+                return Ok(false);
+            }
+            KeyCode::Char('s') => {
+                app.notify_error("编辑进行中,请先 Enter 提交或 Esc 取消,再 Ctrl+S 保存");
                 return Ok(false);
             }
             _ => {}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,0 +1,220 @@
+//! 事件循环与按键分发
+
+use std::time::Duration;
+
+use anyhow::Result;
+use ratatui::backend::Backend;
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::Terminal;
+
+use crate::tui::app::{App, Focus, Mode};
+use crate::tui::view;
+
+pub async fn run_loop<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<()> {
+    while !app.should_quit {
+        terminal.draw(|frame| view::render(frame, app))?;
+
+        if event::poll(Duration::from_millis(200))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    let preview_changed = handle_key(app, key).await?;
+                    if preview_changed {
+                        app.refresh_preview().await;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// 处理一次按键;返回 `true` 表示配置可能已变,需要刷新预览。
+async fn handle_key(app: &mut App, key: KeyEvent) -> Result<bool> {
+    // 全局 Ctrl 组合
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return handle_ctrl(app, key).await;
+    }
+
+    if app.help_visible {
+        match key.code {
+            KeyCode::Char('?') | KeyCode::Esc => app.toggle_help(),
+            _ => {}
+        }
+        return Ok(false);
+    }
+
+    if app.merge_report_visible {
+        match key.code {
+            KeyCode::F(2) | KeyCode::Esc => app.toggle_merge_report(),
+            _ => {}
+        }
+        return Ok(false);
+    }
+
+    if app.search.is_some() {
+        return Ok(handle_search(app, key));
+    }
+
+    match &app.mode {
+        Mode::Normal => Ok(handle_normal(app, key)),
+        Mode::EditText(_) => Ok(handle_edit_text(app, key)),
+    }
+}
+
+fn handle_search(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.close_search();
+            false
+        }
+        KeyCode::Enter => {
+            app.search_commit();
+            false
+        }
+        KeyCode::Up => {
+            app.search_move(-1);
+            false
+        }
+        KeyCode::Down => {
+            app.search_move(1);
+            false
+        }
+        KeyCode::Backspace => {
+            app.search_backspace();
+            false
+        }
+        KeyCode::Char(c) => {
+            app.search_push_char(c);
+            false
+        }
+        _ => false,
+    }
+}
+
+async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
+    match key.code {
+        KeyCode::Char('q') => {
+            app.request_quit();
+            Ok(false)
+        }
+        KeyCode::Char('s') => {
+            app.save()?;
+            Ok(true)
+        }
+        KeyCode::Char('r') => {
+            app.revert();
+            Ok(true)
+        }
+        KeyCode::Char('m') => {
+            app.cycle_mock();
+            Ok(true)
+        }
+        KeyCode::Char('t') => {
+            app.switch_scope().await;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn handle_normal(app: &mut App, key: KeyEvent) -> bool {
+    // Widgets Tab 有独立的键集合
+    if app.is_widgets_tab() {
+        return handle_widgets_tab(app, key);
+    }
+
+    let mut changed = false;
+    match key.code {
+        KeyCode::Tab | KeyCode::Right => app.next_tab(),
+        KeyCode::BackTab | KeyCode::Left => app.prev_tab(),
+        KeyCode::Up => {
+            app.focus = Focus::Fields;
+            app.prev_field();
+        }
+        KeyCode::Down => {
+            app.focus = Focus::Fields;
+            app.next_field();
+        }
+        KeyCode::Char(' ') => {
+            app.space_action();
+            changed = true;
+        }
+        KeyCode::Enter => {
+            app.begin_edit();
+            changed = matches!(app.mode, Mode::Normal);
+        }
+        KeyCode::Char('?') => app.toggle_help(),
+        KeyCode::Char('/') => app.open_search(),
+        KeyCode::F(2) => app.toggle_merge_report(),
+        _ => {}
+    }
+    changed
+}
+
+fn handle_widgets_tab(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Tab | KeyCode::Right => {
+            app.next_tab();
+            false
+        }
+        KeyCode::BackTab | KeyCode::Left => {
+            app.prev_tab();
+            false
+        }
+        KeyCode::Up => {
+            app.widget_prev();
+            false
+        }
+        KeyCode::Down => {
+            app.widget_next();
+            false
+        }
+        KeyCode::Char(' ') => {
+            app.widget_toggle_enabled();
+            true
+        }
+        KeyCode::Char('t') => {
+            app.widget_cycle_type();
+            true
+        }
+        KeyCode::Char('d') | KeyCode::Delete => {
+            app.widget_delete();
+            true
+        }
+        KeyCode::Char('?') => {
+            app.toggle_help();
+            false
+        }
+        KeyCode::Char('/') => {
+            app.open_search();
+            false
+        }
+        KeyCode::F(2) => {
+            app.toggle_merge_report();
+            false
+        }
+        _ => false,
+    }
+}
+
+fn handle_edit_text(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.cancel_edit();
+            false
+        }
+        KeyCode::Enter => {
+            app.commit_edit();
+            true
+        }
+        KeyCode::Backspace => {
+            app.edit_backspace();
+            false
+        }
+        KeyCode::Char(c) => {
+            app.edit_push_char(c);
+            false
+        }
+        _ => false,
+    }
+}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -118,7 +118,11 @@ fn handle_search(app: &mut App, key: KeyEvent) -> bool {
 }
 
 async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
-    // 文本编辑模式里 Ctrl+A/E 走行首/行尾,不被全局保存等吃掉
+    // 文本编辑模式里只放行安全的 Ctrl 组合:
+    // - Ctrl+A / Ctrl+E 行首/行尾(编辑器自己的键)
+    // - Ctrl+Q 直接退出(用户放弃编辑,可接受)
+    // - Ctrl+T 会改 section_idx/field_idx,把 buffer 指向另一个字段后的
+    //   Enter 会把错误内容写进新字段。必须拒绝。
     if matches!(app.mode, Mode::EditText(_)) {
         match key.code {
             KeyCode::Char('a') => {
@@ -127,6 +131,10 @@ async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
             }
             KeyCode::Char('e') => {
                 app.edit_end();
+                return Ok(false);
+            }
+            KeyCode::Char('t') => {
+                app.notify_error("编辑进行中,请先 Enter 提交或 Esc 取消,再切 scope");
                 return Ok(false);
             }
             _ => {}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -147,7 +147,7 @@ async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
             Ok(false)
         }
         KeyCode::Char('s') => {
-            app.save()?;
+            app.save().await?;
             Ok(true)
         }
         KeyCode::Char('r') => {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -159,6 +159,33 @@ async fn handle_ctrl(app: &mut App, key: KeyEvent) -> Result<bool> {
         }
     }
 
+    // widget_new 对话框进行中:dialog 持有 target_path 指向打开对话框时的
+    // scope。如果放行 Ctrl+T,switch_scope 会切目标文件但 target_path 不动,
+    // 用户下一下 Enter 就把新 widget 写进旧 layer 的文件,UI 却已经切到新
+    // scope —— 静默写错 layer。一并挡掉 Ctrl+S / Ctrl+R:它们会操作主
+    // document(保存/回滚),但此刻用户心智在 modal 上,背景里悄悄改持久化
+    // 状态一样糟糕。Ctrl+Q 允许(明确意图:放弃一切退出),Ctrl+M 允许
+    // (只改 mock_idx,不碰持久化状态)。
+    if app.widget_new.is_some() {
+        match key.code {
+            KeyCode::Char('t') => {
+                app.notify_error(
+                    "新建 widget 进行中,请先 Enter 提交或 Esc 取消,再 Ctrl+T 切 scope",
+                );
+                return Ok(false);
+            }
+            KeyCode::Char('s') => {
+                app.notify_error("新建 widget 进行中,请先 Enter 提交或 Esc 取消,再 Ctrl+S 保存");
+                return Ok(false);
+            }
+            KeyCode::Char('r') => {
+                app.notify_error("新建 widget 进行中,请先 Enter 提交或 Esc 取消,再 Ctrl+R 撤销");
+                return Ok(false);
+            }
+            _ => {}
+        }
+    }
+
     match key.code {
         KeyCode::Char('q') => {
             app.request_quit();

--- a/src/tui/io.rs
+++ b/src/tui/io.rs
@@ -3,9 +3,11 @@
 //! 用 `toml_edit` 而不是 `toml::to_string`,保留配置文件里的注释和顺序。
 
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
+use tempfile::NamedTempFile;
 use toml_edit::{value as toml_value, DocumentMut, InlineTable, Item, Table, Value};
 
 /// 读取已有文件;不存在则返回空 `DocumentMut`。
@@ -22,15 +24,32 @@ pub fn load_or_create(path: &Path) -> Result<DocumentMut> {
 }
 
 /// 原子写入。
+///
+/// 使用 `NamedTempFile::persist`:同卷内临时文件 → 原子替换目标。这点很关键
+/// —— 以前用 `fs::rename(&tmp, path)`,在 Windows 某些版本和某些路径下会
+/// 因为目标文件已存在而失败(`fs::rename` 的 replace 语义在 Windows 上有
+/// 历史坑),导致"编辑现有 config.toml 时第二次保存必挂"。
+/// NamedTempFile::persist 底层走 `MoveFileExW` + `MOVEFILE_REPLACE_EXISTING`,
+/// 把"目标存在就替换"的语义落实到平台 API,跨平台一致。
 pub fn save(path: &Path, doc: &DocumentMut) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("无法创建目录: {}", parent.display()))?;
     }
-    let tmp = path.with_extension("toml.tmp");
-    fs::write(&tmp, doc.to_string())
-        .with_context(|| format!("写临时文件失败: {}", tmp.display()))?;
-    fs::rename(&tmp, path).with_context(|| format!("原子重命名失败: {}", path.display()))?;
+    // 把临时文件创建在目标文件所在目录,persist 就是同卷 rename,必然原子。
+    // 放在系统默认 temp dir 会跨卷,persist 降级成 copy+delete,不原子。
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("创建临时文件失败(目录 {})", parent.display()))?;
+    tmp.write_all(doc.to_string().as_bytes())
+        .with_context(|| format!("写临时文件失败: {}", tmp.path().display()))?;
+    // 显式 sync 让内容真正落盘再 rename,配合 tempfile 就是 write-temp
+    // + fsync + atomic-replace 的标准三步。
+    tmp.as_file_mut()
+        .sync_all()
+        .with_context(|| format!("flush 临时文件失败: {}", tmp.path().display()))?;
+    tmp.persist(path)
+        .map_err(|err| anyhow!("原子替换失败 {}: {}", path.display(), err.error))?;
     Ok(())
 }
 
@@ -216,6 +235,33 @@ mod tests {
         let mut doc = DocumentMut::new();
         set_int(&mut doc, "multiline.max_rows", 7)?;
         assert_eq!(get_int(&doc, "multiline.max_rows"), Some(7));
+        Ok(())
+    }
+
+    /// 回归 Codex round 13 / P1:save() 必须能覆盖已经存在的目标文件。
+    /// 以前用 `fs::rename(&tmp, path)`,在 Windows 上遇到已存在文件会失败,
+    /// 导致"编辑现有 config.toml 的第二次保存永远挂"。这个测试在类 Unix
+    /// 上本来就能过,但它记录了这项不变式,跨平台 CI 会帮我们校验 Windows。
+    #[test]
+    fn test_save_overwrites_existing_file() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("config.toml");
+
+        // 第一次写
+        let mut doc1 = DocumentMut::new();
+        set_string(&mut doc1, "preset", "PMBT")?;
+        save(&path, &doc1)?;
+        let content1 = std::fs::read_to_string(&path)?;
+        assert!(content1.contains("\"PMBT\""));
+
+        // 第二次写同一个路径(关键:这次目标文件已经存在)
+        let mut doc2 = DocumentMut::new();
+        set_string(&mut doc2, "preset", "PMBTUS")?;
+        save(&path, &doc2)?;
+
+        let content2 = std::fs::read_to_string(&path)?;
+        assert!(content2.contains("\"PMBTUS\""));
+        assert!(!content2.contains("\"PMBT\"\n"));
         Ok(())
     }
 

--- a/src/tui/io.rs
+++ b/src/tui/io.rs
@@ -1,0 +1,171 @@
+//! 文件 IO 与 `toml_edit::DocumentMut` 的点路径读写助手
+//!
+//! 用 `toml_edit` 而不是 `toml::to_string`,保留配置文件里的注释和顺序。
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use toml_edit::{value as toml_value, DocumentMut, Item, Table};
+
+/// 读取已有文件;不存在则返回空 `DocumentMut`。
+pub fn load_or_create(path: &Path) -> Result<DocumentMut> {
+    if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("无法读取配置文件: {}", path.display()))?;
+        content
+            .parse::<DocumentMut>()
+            .map_err(|err| anyhow!("TOML 格式错误: {} ({err})", path.display()))
+    } else {
+        Ok(DocumentMut::new())
+    }
+}
+
+/// 原子写入。
+pub fn save(path: &Path, doc: &DocumentMut) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("无法创建目录: {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("toml.tmp");
+    fs::write(&tmp, doc.to_string())
+        .with_context(|| format!("写临时文件失败: {}", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("原子重命名失败: {}", path.display()))?;
+    Ok(())
+}
+
+// ---- 读取 ----
+
+pub fn get_string(doc: &DocumentMut, dotted: &str) -> Option<String> {
+    traverse(doc, dotted).and_then(|item| item.as_str().map(std::string::ToString::to_string))
+}
+
+pub fn get_bool(doc: &DocumentMut, dotted: &str) -> Option<bool> {
+    traverse(doc, dotted).and_then(Item::as_bool)
+}
+
+pub fn get_int(doc: &DocumentMut, dotted: &str) -> Option<i64> {
+    traverse(doc, dotted).and_then(Item::as_integer)
+}
+
+pub fn get_float(doc: &DocumentMut, dotted: &str) -> Option<f64> {
+    let item = traverse(doc, dotted)?;
+    item.as_float()
+        .or_else(|| item.as_integer().map(|n| n as f64))
+}
+
+// ---- 写入 ----
+
+pub fn set_string(doc: &mut DocumentMut, dotted: &str, v: &str) -> Result<()> {
+    set_item(doc, dotted, toml_value(v))
+}
+
+pub fn set_bool(doc: &mut DocumentMut, dotted: &str, v: bool) -> Result<()> {
+    set_item(doc, dotted, toml_value(v))
+}
+
+pub fn set_int(doc: &mut DocumentMut, dotted: &str, v: i64) -> Result<()> {
+    set_item(doc, dotted, toml_value(v))
+}
+
+pub fn set_float(doc: &mut DocumentMut, dotted: &str, v: f64) -> Result<()> {
+    set_item(doc, dotted, toml_value(v))
+}
+
+// ---- 内部 ----
+
+fn traverse<'a>(doc: &'a DocumentMut, dotted: &str) -> Option<&'a Item> {
+    let mut current: &Item = doc.as_item();
+    for seg in dotted.split('.') {
+        let table = current.as_table_like()?;
+        current = table.get(seg)?;
+    }
+    Some(current)
+}
+
+fn set_item(doc: &mut DocumentMut, dotted: &str, value: Item) -> Result<()> {
+    let parts: Vec<&str> = dotted.split('.').collect();
+    if parts.is_empty() {
+        bail!("配置键不能为空");
+    }
+    set_recursive(doc.as_table_mut(), &parts, value)
+}
+
+fn set_recursive(table: &mut Table, parts: &[&str], value: Item) -> Result<()> {
+    let (head, rest) = parts
+        .split_first()
+        .ok_or_else(|| anyhow!("内部错误: 路径为空"))?;
+    if rest.is_empty() {
+        replace_preserving_decor(table, head, value);
+        return Ok(());
+    }
+    if !table.contains_key(head) {
+        let mut sub = Table::new();
+        sub.set_implicit(true);
+        table.insert(head, Item::Table(sub));
+    }
+    let child = table
+        .get_mut(head)
+        .ok_or_else(|| anyhow!("内部错误: 无法定位 {head}"))?;
+    if let Some(subtable) = child.as_table_mut() {
+        set_recursive(subtable, rest, value)
+    } else {
+        bail!("路径 {head} 已存在但不是表,无法继续写入")
+    }
+}
+
+/// 替换叶子值时尽量保留原有的格式 decor(前后空格、注释)。
+fn replace_preserving_decor(table: &mut Table, key: &str, value: Item) {
+    if let (Some(existing), Item::Value(new_value)) = (table.get_mut(key), &value) {
+        if let Item::Value(existing_value) = existing {
+            let decor = existing_value.decor().clone();
+            let mut new_value = new_value.clone();
+            *new_value.decor_mut() = decor;
+            *existing = Item::Value(new_value);
+            return;
+        }
+    }
+    table.insert(key, value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_round_trip_string() -> Result<()> {
+        let mut doc = DocumentMut::new();
+        set_string(&mut doc, "preset", "PMBT")?;
+        assert_eq!(get_string(&doc, "preset").as_deref(), Some("PMBT"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_path_creates_tables() -> Result<()> {
+        let mut doc = DocumentMut::new();
+        set_bool(&mut doc, "terminal.force_nerd_font", true)?;
+        assert_eq!(get_bool(&doc, "terminal.force_nerd_font"), Some(true));
+        assert!(doc.to_string().contains("[terminal]"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_preserves_comments() -> Result<()> {
+        let src = "# 顶部注释\npreset = \"PMBT\"\n";
+        let mut doc = src.parse::<DocumentMut>()?;
+        set_string(&mut doc, "preset", "PMBTUS")?;
+        let out = doc.to_string();
+        assert!(out.contains("# 顶部注释"));
+        assert!(out.contains("PMBTUS"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_int_round_trip() -> Result<()> {
+        let mut doc = DocumentMut::new();
+        set_int(&mut doc, "multiline.max_rows", 7)?;
+        assert_eq!(get_int(&doc, "multiline.max_rows"), Some(7));
+        Ok(())
+    }
+}

--- a/src/tui/io.rs
+++ b/src/tui/io.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
-use toml_edit::{value as toml_value, DocumentMut, Item, Table};
+use toml_edit::{value as toml_value, DocumentMut, InlineTable, Item, Table, Value};
 
 /// 读取已有文件;不存在则返回空 `DocumentMut`。
 pub fn load_or_create(path: &Path) -> Result<DocumentMut> {
@@ -107,11 +107,49 @@ fn set_recursive(table: &mut Table, parts: &[&str], value: Item) -> Result<()> {
     let child = table
         .get_mut(head)
         .ok_or_else(|| anyhow!("内部错误: 无法定位 {head}"))?;
+    // 优先走普通 Table 分支(99% 的配置都长这样),其次接受 inline table。
+    // 以前这里只识别 as_table_mut(),导致 `style = { separator = "|" }`
+    // 这种完全合法的 TOML 一旦存在,编辑器写 `style.separator` 就会 bail
+    // "已存在但不是表",相当于让合法配置变只读。读路径用的是 as_table_like()
+    // 天然支持两者,写路径现在也对齐。
     if let Some(subtable) = child.as_table_mut() {
-        set_recursive(subtable, rest, value)
-    } else {
-        bail!("路径 {head} 已存在但不是表,无法继续写入")
+        return set_recursive(subtable, rest, value);
     }
+    if let Item::Value(Value::InlineTable(ref mut inline)) = child {
+        return set_recursive_inline(inline, rest, value);
+    }
+    bail!("路径 {head} 已存在但不是表,无法继续写入")
+}
+
+/// 沿 inline 表(`{ ... }`)继续下钻。
+///
+/// inline 表只能装 `Value`,不能直接塞 `Item::Table`。叶子值的写法跟
+/// 普通表基本一致,但要把 `Item::Value(v)` 拆成 `v`。所有现有的
+/// `set_string/set_bool/...` 都经 `toml_value(...)` 返回 `Item::Value`,
+/// 所以 `into_value()` 实际上永远成功;报错分支仅作未来兜底。
+fn set_recursive_inline(inline: &mut InlineTable, parts: &[&str], value: Item) -> Result<()> {
+    let (head, rest) = parts
+        .split_first()
+        .ok_or_else(|| anyhow!("内部错误: 路径为空"))?;
+    if rest.is_empty() {
+        let new_value = value
+            .into_value()
+            .map_err(|_| anyhow!("无法把非 Value 项写入 inline 表的叶子 {head}"))?;
+        replace_inline_preserving_decor(inline, head, new_value);
+        return Ok(());
+    }
+    if !inline.contains_key(head) {
+        // InlineTable::insert 的 key 要 impl Into<String>,`&&str` 不行,
+        // 手动 deref 成 `&str` 让编译器走 String::from 路径。
+        inline.insert(*head, Value::InlineTable(InlineTable::new()));
+    }
+    let child = inline
+        .get_mut(head)
+        .ok_or_else(|| anyhow!("内部错误: 无法定位 {head}"))?;
+    if let Some(subinline) = child.as_inline_table_mut() {
+        return set_recursive_inline(subinline, rest, value);
+    }
+    bail!("路径 {head} 已存在但不是表,无法继续写入")
 }
 
 /// 替换叶子值时尽量保留原有的格式 decor(前后空格、注释)。
@@ -126,6 +164,18 @@ fn replace_preserving_decor(table: &mut Table, key: &str, value: Item) {
         }
     }
     table.insert(key, value);
+}
+
+/// inline 表的叶子写入,同样尽量保留 decor。
+fn replace_inline_preserving_decor(inline: &mut InlineTable, key: &str, value: Value) {
+    if let Some(existing) = inline.get_mut(key) {
+        let decor = existing.decor().clone();
+        let mut new_value = value;
+        *new_value.decor_mut() = decor;
+        *existing = new_value;
+        return;
+    }
+    inline.insert(key, value);
 }
 
 #[cfg(test)]
@@ -167,5 +217,61 @@ mod tests {
         set_int(&mut doc, "multiline.max_rows", 7)?;
         assert_eq!(get_int(&doc, "multiline.max_rows"), Some(7));
         Ok(())
+    }
+
+    /// 回归:`style = { separator = "|" }` 这种合法 TOML 使用 inline table,
+    /// 以前 set_recursive 只认 as_table_mut(),会 bail "已存在但不是表"。
+    /// 修好以后 set_string 写 `style.separator` 必须成功,且读回来能拿到新值。
+    #[test]
+    fn test_set_updates_existing_inline_table_leaf() -> Result<()> {
+        let src = r#"style = { separator = "|", spacing = 1 }
+"#;
+        let mut doc = src.parse::<DocumentMut>()?;
+        set_string(&mut doc, "style.separator", " > ")?;
+        assert_eq!(get_string(&doc, "style.separator").as_deref(), Some(" > "));
+        // 同一 inline 表里的 sibling 必须保留,不能被整块替换
+        assert_eq!(get_int(&doc, "style.spacing"), Some(1));
+        // 序列化后仍然是 inline 格式(至少能读回来),不必强求 `{}` 字形
+        let out = doc.to_string();
+        assert!(out.contains(" > "));
+        assert!(out.contains("spacing"));
+        Ok(())
+    }
+
+    /// inline 表缺失要写入的 key 时,应该允许原地 insert,不是报错。
+    #[test]
+    fn test_set_adds_new_key_to_existing_inline_table() -> Result<()> {
+        let src = r#"style = { separator = "|" }
+"#;
+        let mut doc = src.parse::<DocumentMut>()?;
+        set_bool(&mut doc, "style.bold", true)?;
+        assert_eq!(get_bool(&doc, "style.bold"), Some(true));
+        assert_eq!(get_string(&doc, "style.separator").as_deref(), Some("|"));
+        Ok(())
+    }
+
+    /// 嵌套 inline(`a = { b = { c = "x" } }`)也得能写深层叶子。
+    #[test]
+    fn test_set_walks_nested_inline_tables() -> Result<()> {
+        let src = r#"a = { b = { c = "x" } }
+"#;
+        let mut doc = src.parse::<DocumentMut>()?;
+        set_string(&mut doc, "a.b.c", "y")?;
+        assert_eq!(get_string(&doc, "a.b.c").as_deref(), Some("y"));
+        Ok(())
+    }
+
+    /// 把 inline 表里原本是 Value 的字段当成子表继续下钻,必须报错,
+    /// 不能因为新增了 inline 分支就悄悄把一个字符串变成子表。
+    #[test]
+    fn test_set_rejects_descending_into_inline_scalar() {
+        let src = r#"style = { separator = "|" }
+"#;
+        let mut doc = src.parse::<DocumentMut>().unwrap();
+        let err = set_string(&mut doc, "style.separator.sub", "x").unwrap_err();
+        assert!(
+            err.to_string().contains("不是表"),
+            "expected table-type error, got: {err}"
+        );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -47,17 +47,32 @@ pub async fn run(options: EditOptions) -> Result<()> {
         bail!("`config edit` 需要交互式终端(TTY),当前 stdin/stdout 不是 TTY。");
     }
 
+    // 先构造 App。任何 IO / 解析错误要在进入 raw mode 之前发生,
+    // 否则错误返回路径会把用户终端留在 raw mode + alternate screen 里。
+    let mut app = app::App::from_options(options).await?;
+
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    if let Err(err) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
+        let _ = disable_raw_mode();
+        return Err(err.into());
+    }
 
+    // 从这里起必须保证 cleanup 被执行
     let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(err) => {
+            let mut out = std::io::stdout();
+            let _ = execute!(out, LeaveAlternateScreen, DisableMouseCapture);
+            let _ = disable_raw_mode();
+            return Err(err.into());
+        }
+    };
 
-    let mut app = app::App::from_options(options).await?;
     let loop_result = event::run_loop(&mut terminal, &mut app).await;
 
-    // 无论成功还是失败,都要恢复终端
+    // 无论 loop 成功还是失败都恢复终端
     let _ = disable_raw_mode();
     let _ = execute!(
         terminal.backend_mut(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -54,6 +54,13 @@ pub async fn run(options: EditOptions) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     if let Err(err) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
+        // execute! 失败不代表前面的 control sequence 一个都没写出:如果
+        // EnterAlternateScreen 已经成功、EnableMouseCapture 才失败,用户的
+        // 终端现在就卡在 alt screen + raw mode 里,我们这里只 disable_raw_mode
+        // 不够,alt screen 和鼠标捕获必须一起关掉。和下面 Terminal::new 失败
+        // 路径对齐。反向 execute! 本身也可能失败,用 let _ 忽略,优先把原始
+        // 错误吐出去让用户知道到底哪里挂了。
+        let _ = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture);
         let _ = disable_raw_mode();
         return Err(err.into());
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,101 @@
+//! TUI 配置编辑器(v1)
+//!
+//! 架构:
+//! - `sections`:静态字段元数据
+//! - `io`:`toml_edit::DocumentMut` 读写,保留注释
+//! - `preview`:用当前配置 + mock 数据生成预览行
+//! - `app`:状态机
+//! - `view`:ratatui 渲染
+//! - `event`:按键分发
+//!
+//! 进入方式:`ccsp config edit [--global | --file <path>] [--mock <scenario>]`
+
+#![allow(
+    clippy::too_many_lines,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions
+)]
+
+mod app;
+mod event;
+mod io;
+mod preview;
+mod sections;
+mod view;
+mod widgets;
+
+use std::io::IsTerminal;
+
+use anyhow::{bail, Result};
+use ratatui::crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::prelude::CrosstermBackend;
+use ratatui::Terminal;
+use toml_edit::DocumentMut;
+
+pub use app::{EditOptions, EditScope};
+
+use crate::tui::sections::{Field, FieldKind};
+
+/// 启动 TUI 编辑器。
+pub async fn run(options: EditOptions) -> Result<()> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!("`config edit` 需要交互式终端(TTY),当前 stdin/stdout 不是 TTY。");
+    }
+
+    enable_raw_mode()?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = app::App::from_options(options).await?;
+    let loop_result = event::run_loop(&mut terminal, &mut app).await;
+
+    // 无论成功还是失败,都要恢复终端
+    let _ = disable_raw_mode();
+    let _ = execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    );
+    let _ = terminal.show_cursor();
+
+    loop_result
+}
+
+/// 把当前字段的值格式化成"显示文本"(用于列表右侧)。
+pub(crate) fn get_field_display(doc: &DocumentMut, field: &Field) -> String {
+    match field.kind {
+        FieldKind::Text | FieldKind::Enum(_) | FieldKind::Color => {
+            io::get_string(doc, field.path).map_or_else(|| "—".to_string(), |v| format!("\"{v}\""))
+        }
+        FieldKind::Bool => io::get_bool(doc, field.path).map_or_else(
+            || "—".to_string(),
+            |v| if v { "true" } else { "false" }.to_string(),
+        ),
+        FieldKind::Int { .. } => {
+            io::get_int(doc, field.path).map_or_else(|| "—".to_string(), |v| v.to_string())
+        }
+        FieldKind::Float { .. } => {
+            io::get_float(doc, field.path).map_or_else(|| "—".to_string(), |v| format!("{v:.2}"))
+        }
+    }
+}
+
+/// mock 场景的中文友好标签。
+pub(crate) fn get_mock_label(name: &str) -> String {
+    match name {
+        "dev" => "dev · 开发会话".to_string(),
+        "critical" => "critical · 高负载".to_string(),
+        "thinking" => "thinking · 思考中".to_string(),
+        "complete" => "complete · 已完成".to_string(),
+        "error" => "error · 错误态".to_string(),
+        other => other.to_string(),
+    }
+}

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -128,6 +128,34 @@ fn walk_json_bool(root: &serde_json::Value, dotted: &str) -> Option<bool> {
     current.as_bool()
 }
 
+/// 和 `effective_bool` 同一套语义,但返回 `String`。`cycle_enum`(Enum / Color
+/// 快捷切换)必须走这条路径:以前只读 `self.document` 就忽略了用户/项目层
+/// 已经设好的值,用户第一次按空格时,"下一个"选项是相对于 option[0](而不是
+/// 相对于当前生效值)计算的——举例:用户层 `theme = "powerline"`,本地 buffer
+/// 完全没提 theme,按一次空格应该切到 "capsule",但旧实现读到 "" 找不到
+/// 匹配就回 index 0,把 theme 设回 "classic"(即 options[0]),等于倒退一步。
+pub fn effective_string(
+    document: &DocumentMut,
+    inherited: &serde_json::Value,
+    dotted: &str,
+) -> Option<String> {
+    let buffer_overlay: serde_json::Value = toml_edit::de::from_str(&document.to_string()).ok()?;
+    if !buffer_overlay.is_object() {
+        return walk_json_string(inherited, dotted);
+    }
+    let mut merged = inherited.clone();
+    merge_json(&mut merged, buffer_overlay);
+    walk_json_string(&merged, dotted)
+}
+
+fn walk_json_string(root: &serde_json::Value, dotted: &str) -> Option<String> {
+    let mut current = root;
+    for seg in dotted.split('.') {
+        current = current.get(seg)?;
+    }
+    current.as_str().map(std::string::ToString::to_string)
+}
+
 /// 与 `ConfigLoader::merge_value` 语义保持一致:object 合并,其他直接覆盖。
 ///
 /// `pub(crate)` 是为了让 `tui::app` 在计算 inherited baseline 时能直接复用
@@ -357,6 +385,39 @@ enabled = "yes"
         inherited["components"]["project"]["enabled"] = serde_json::Value::Bool(false);
         let v = effective_bool(&doc, &inherited, "components.project.enabled");
         assert_eq!(v, Some(false));
+        Ok(())
+    }
+
+    /// 回归 Codex round 8 / P2:enum/color cycle 必须从 effective 值起跳。
+    /// 典型场景:用户层 `theme = "powerline"`,项目 buffer 没提 theme;
+    /// cycle_enum 需要从 effective string "powerline" 开始算"下一个"。
+    #[test]
+    fn test_effective_string_reads_inherited_when_buffer_silent() -> Result<()> {
+        let doc: DocumentMut = "".parse()?;
+        let mut inherited = defaults_json();
+        inherited["theme"] = serde_json::Value::String("powerline".to_string());
+        let v = effective_string(&doc, &inherited, "theme");
+        assert_eq!(v.as_deref(), Some("powerline"));
+        Ok(())
+    }
+
+    /// buffer 显式写了 theme,必须盖过 inherited。
+    #[test]
+    fn test_effective_string_buffer_beats_inherited() -> Result<()> {
+        let doc: DocumentMut = "theme = \"capsule\"\n".parse()?;
+        let mut inherited = defaults_json();
+        inherited["theme"] = serde_json::Value::String("powerline".to_string());
+        let v = effective_string(&doc, &inherited, "theme");
+        assert_eq!(v.as_deref(), Some("capsule"));
+        Ok(())
+    }
+
+    /// 拿不到就返回 None,交给调用方决定怎么 fallback。
+    #[test]
+    fn test_effective_string_missing_key_returns_none() -> Result<()> {
+        let doc: DocumentMut = "".parse()?;
+        let v = effective_string(&doc, &defaults_json(), "totally.not.a.real.key");
+        assert_eq!(v, None);
         Ok(())
     }
 }

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -58,9 +58,41 @@ pub fn available_mocks() -> Vec<String> {
     v
 }
 
-/// 从 `DocumentMut` 字符串反序列化到 `Config`;解析错误时包一层上下文。
+/// 把 TOML 当作 `Config::default()` 之上的稀疏 overlay 反序列化。
+///
+/// `ConfigLoader::load_config_layers` 就是这么干的:用户/项目/自定义层都
+/// 按"增量叠加"语义处理,最后再把合并后的 JSON 反序列化到 `Config`。
+/// 如果这里直接 `toml_edit::de::from_str::<Config>`,像 flattened
+/// `BaseComponentConfig`(`emoji_icon` / `nerd_icon` / `text_icon`
+/// 没有 serde default)就会拒绝一切省略了这些键的局部配置 —— 包括
+/// 空文件和首次从最小 override 起步的配置,直接砍掉编辑器的使用场景。
 pub fn parse_config(toml_text: &str) -> Result<Config> {
-    toml_edit::de::from_str::<Config>(toml_text).map_err(|err| anyhow!("{err}"))
+    let mut merged = serde_json::to_value(Config::default())
+        .map_err(|err| anyhow!("序列化默认配置失败: {err}"))?;
+    if !toml_text.trim().is_empty() {
+        let overlay: serde_json::Value =
+            toml_edit::de::from_str(toml_text).map_err(|err| anyhow!("{err}"))?;
+        merge_json(&mut merged, overlay);
+    }
+    serde_json::from_value(merged).map_err(|err| anyhow!("{err}"))
+}
+
+/// 与 `ConfigLoader::merge_value` 语义保持一致:object 合并,其他直接覆盖。
+fn merge_json(base: &mut serde_json::Value, overlay: serde_json::Value) {
+    use serde_json::Value;
+    match (base, overlay) {
+        (Value::Object(base_map), Value::Object(overlay_map)) => {
+            for (k, v) in overlay_map {
+                match base_map.get_mut(&k) {
+                    Some(existing) => merge_json(existing, v),
+                    None => {
+                        base_map.insert(k, v);
+                    }
+                }
+            }
+        }
+        (slot, other) => *slot = other,
+    }
 }
 
 #[cfg(test)]
@@ -108,5 +140,42 @@ mod tests {
         let lines = render(&config, "dev", Some(temp.path())).await?;
         assert!(!lines.is_empty());
         Ok(())
+    }
+
+    /// 回归:稀疏配置(没有覆盖 components.*.emoji_icon 等 flatten 必填字段)
+    /// 必须能通过 parse_config,否则编辑器里首次保存就会被误判为"校验失败"。
+    #[test]
+    fn test_parse_config_accepts_empty_overlay() -> Result<()> {
+        let cfg = parse_config("")?;
+        // 空文件 → 等于全默认
+        assert_eq!(cfg.theme, Config::default().theme);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_config_accepts_sparse_partial_override() -> Result<()> {
+        // 只改一个 preset + 一个嵌套字段,不重复声明 components.project 的 icon
+        let toml = r#"
+preset = "PMBT"
+
+[components.project]
+enabled = false
+"#;
+        let cfg = parse_config(toml)?;
+        assert_eq!(cfg.preset.as_deref(), Some("PMBT"));
+        assert!(!cfg.components.project.base.enabled);
+        // 其他默认值保留
+        assert!(!cfg.components.project.base.emoji_icon.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_config_rejects_type_mismatch() {
+        // 类型错了应该仍然报错(enabled 被写成字符串)
+        let toml = r#"
+[components.project]
+enabled = "yes"
+"#;
+        assert!(parse_config(toml).is_err());
     }
 }

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use ansi_to_tui::IntoText;
 use anyhow::{anyhow, Result};
 use ratatui::text::Line;
+use toml_edit::DocumentMut;
 
 use claude_code_statusline_pro::config::Config;
 use claude_code_statusline_pro::core::{GeneratorOptions, StatuslineGenerator};
@@ -63,7 +64,16 @@ pub fn available_mocks() -> Vec<String> {
     v
 }
 
-/// 把 TOML 当作 `Config::default()` 之上的稀疏 overlay 反序列化。
+/// 把 TOML 当作 `inherited` 之上的稀疏 overlay 反序列化。
+///
+/// `inherited` 一般由调用方(App)按当前编辑的 scope 预先算好:
+/// - `User` 编辑 → inherited = `Config::default()` 的 JSON
+/// - `Project` 编辑 → inherited = default + 用户层
+/// - `Custom` 编辑 → inherited = default + 用户层 + 项目层(走 `ConfigLoader`)
+///
+/// 这样预览才会和真实运行时一致:如果用户层写了 `theme = "powerline"`,
+/// 而项目级配置只覆盖了一个图标,预览里仍然能看到 powerline 主题;
+/// 否则就会错误地回落成默认主题,编辑器等于在假数据上工作。
 ///
 /// `ConfigLoader::load_config_layers` 就是这么干的:用户/项目/自定义层都
 /// 按"增量叠加"语义处理,最后再把合并后的 JSON 反序列化到 `Config`。
@@ -71,9 +81,8 @@ pub fn available_mocks() -> Vec<String> {
 /// `BaseComponentConfig`(`emoji_icon` / `nerd_icon` / `text_icon`
 /// 没有 serde default)就会拒绝一切省略了这些键的局部配置 —— 包括
 /// 空文件和首次从最小 override 起步的配置,直接砍掉编辑器的使用场景。
-pub fn parse_config(toml_text: &str) -> Result<Config> {
-    let mut merged = serde_json::to_value(Config::default())
-        .map_err(|err| anyhow!("序列化默认配置失败: {err}"))?;
+pub fn parse_config(toml_text: &str, inherited: &serde_json::Value) -> Result<Config> {
+    let mut merged = inherited.clone();
     if !toml_text.trim().is_empty() {
         let overlay: serde_json::Value =
             toml_edit::de::from_str(toml_text).map_err(|err| anyhow!("{err}"))?;
@@ -82,8 +91,49 @@ pub fn parse_config(toml_text: &str) -> Result<Config> {
     serde_json::from_value(merged).map_err(|err| anyhow!("{err}"))
 }
 
+/// 返回点路径 `dotted`(形如 `components.project.enabled`)的"最终生效值"
+/// ,按 inherited baseline → 当前 buffer 的顺序合并后再读,拿不到就返回 `None`。
+///
+/// Codex round 7 / P2 的 bool 快捷切换必须走这条路径:之前 `space_action`
+/// 用 `io::get_bool(buffer).unwrap_or(false)`,在 sparse 配置里默认值为 true
+/// 的字段(比如 `enabled`)读到的是 false;第一次按空格只写入 true = 等于没
+/// 变化,用户得按两次才能真关掉一个默认开的开关。现在先合并 inherited
+/// + buffer 再查,就和运行时的"有效值"一致了。
+///
+/// 解析 buffer 失败(不是合法 TOML)时直接返回 `None`,让调用方按"拿不到
+/// 有效值"处理;bail 到 false fallback 是更糟的决策,因为会丢 inherited
+/// 里可能已经有的正确值。
+pub fn effective_bool(
+    document: &DocumentMut,
+    inherited: &serde_json::Value,
+    dotted: &str,
+) -> Option<bool> {
+    let buffer_overlay: serde_json::Value =
+        toml_edit::de::from_str(&document.to_string()).ok()?;
+    if !buffer_overlay.is_object() {
+        // 空文档或不完整 buffer 解析出来可能不是 Object。不进行 merge
+        // (merge_json 对非 Object overlay 会整体替换 base,会把 inherited
+        // 抹平成非对象,从而导致后面的 .get 走不下去),直接查 inherited。
+        return walk_json_bool(inherited, dotted);
+    }
+    let mut merged = inherited.clone();
+    merge_json(&mut merged, buffer_overlay);
+    walk_json_bool(&merged, dotted)
+}
+
+fn walk_json_bool(root: &serde_json::Value, dotted: &str) -> Option<bool> {
+    let mut current = root;
+    for seg in dotted.split('.') {
+        current = current.get(seg)?;
+    }
+    current.as_bool()
+}
+
 /// 与 `ConfigLoader::merge_value` 语义保持一致:object 合并,其他直接覆盖。
-fn merge_json(base: &mut serde_json::Value, overlay: serde_json::Value) {
+///
+/// `pub(crate)` 是为了让 `tui::app` 在计算 inherited baseline 时能直接复用
+/// 这套合并逻辑,免得在两个地方写两份容易漂的规则。
+pub(crate) fn merge_json(base: &mut serde_json::Value, overlay: serde_json::Value) {
     use serde_json::Value;
     match (base, overlay) {
         (Value::Object(base_map), Value::Object(overlay_map)) => {
@@ -194,11 +244,15 @@ mod tests {
         Ok(())
     }
 
+    fn defaults_json() -> serde_json::Value {
+        serde_json::to_value(Config::default()).expect("default config serializable")
+    }
+
     /// 回归:稀疏配置(没有覆盖 components.*.emoji_icon 等 flatten 必填字段)
     /// 必须能通过 parse_config,否则编辑器里首次保存就会被误判为"校验失败"。
     #[test]
     fn test_parse_config_accepts_empty_overlay() -> Result<()> {
-        let cfg = parse_config("")?;
+        let cfg = parse_config("", &defaults_json())?;
         // 空文件 → 等于全默认
         assert_eq!(cfg.theme, Config::default().theme);
         Ok(())
@@ -213,7 +267,7 @@ preset = "PMBT"
 [components.project]
 enabled = false
 "#;
-        let cfg = parse_config(toml)?;
+        let cfg = parse_config(toml, &defaults_json())?;
         assert_eq!(cfg.preset.as_deref(), Some("PMBT"));
         assert!(!cfg.components.project.base.enabled);
         // 其他默认值保留
@@ -228,6 +282,83 @@ enabled = false
 [components.project]
 enabled = "yes"
 "#;
-        assert!(parse_config(toml).is_err());
+        assert!(parse_config(toml, &defaults_json()).is_err());
+    }
+
+    /// 回归:当 inherited(= 用户层/项目层)里已经设置了某字段而 buffer
+    /// 没提到它,parse_config 必须透传 inherited 的值,不能让它回落到
+    /// `Config::default()`。这是 Codex round 7 的 P1 核心场景:以前编辑
+    /// 项目级配置时预览完全看不到用户层的 theme,等于在错误 baseline 上工作。
+    #[test]
+    fn test_parse_config_inherits_lower_layer_values() -> Result<()> {
+        let mut inherited = defaults_json();
+        inherited["theme"] = serde_json::Value::String("powerline".to_string());
+
+        let buffer = r#"preset = "PMBT"
+"#;
+        let cfg = parse_config(buffer, &inherited)?;
+        assert_eq!(cfg.theme, "powerline", "inherited theme 必须保留");
+        assert_eq!(cfg.preset.as_deref(), Some("PMBT"));
+        Ok(())
+    }
+
+    /// buffer 显式写同一个 key 时必须能覆盖 inherited 的值。
+    #[test]
+    fn test_parse_config_buffer_overrides_inherited() -> Result<()> {
+        let mut inherited = defaults_json();
+        inherited["theme"] = serde_json::Value::String("powerline".to_string());
+
+        let buffer = r#"theme = "classic"
+"#;
+        let cfg = parse_config(buffer, &inherited)?;
+        assert_eq!(cfg.theme, "classic");
+        Ok(())
+    }
+
+    /// 回归 Codex round 7 / P2:bool 快捷切换必须从"最终生效值"起跳。
+    /// Config::default() 里 `components.project.enabled = true`,如果 buffer
+    /// 完全没提到这个 key,effective_bool 要拿到 true;之前 unwrap_or(false)
+    /// 会读到 false,第一次按空格写入 true 等于没变化。
+    #[test]
+    fn test_effective_bool_reads_default_true_when_buffer_silent() -> Result<()> {
+        let doc: DocumentMut = "".parse()?;
+        let inherited = defaults_json();
+        // default 里这个字段应该就是 true(components.project.enabled)
+        let v = effective_bool(&doc, &inherited, "components.project.enabled");
+        assert_eq!(v, Some(true));
+        Ok(())
+    }
+
+    /// buffer 覆盖 inherited 的情况。
+    #[test]
+    fn test_effective_bool_buffer_beats_inherited() -> Result<()> {
+        let doc: DocumentMut = "[components.project]\nenabled = false\n".parse()?;
+        let inherited = defaults_json();
+        let v = effective_bool(&doc, &inherited, "components.project.enabled");
+        assert_eq!(v, Some(false));
+        Ok(())
+    }
+
+    /// inherited 里不存在的字段,effective_bool 返回 None,交给调用方决定 fallback。
+    #[test]
+    fn test_effective_bool_missing_key_returns_none() -> Result<()> {
+        let doc: DocumentMut = "".parse()?;
+        let inherited = defaults_json();
+        let v = effective_bool(&doc, &inherited, "components.project.not_a_field");
+        assert_eq!(v, None);
+        Ok(())
+    }
+
+    /// inherited 里用户层已经把默认 true 的开关改成 false,buffer 又没提,
+    /// effective_bool 必须拿到 inherited 的 false,而不是回落到 default 的 true。
+    #[test]
+    fn test_effective_bool_inherited_beats_default() -> Result<()> {
+        let doc: DocumentMut = "".parse()?;
+        let mut inherited = defaults_json();
+        inherited["components"]["project"]["enabled"] =
+            serde_json::Value::Bool(false);
+        let v = effective_bool(&doc, &inherited, "components.project.enabled");
+        assert_eq!(v, Some(false));
+        Ok(())
     }
 }

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -108,8 +108,7 @@ pub fn effective_bool(
     inherited: &serde_json::Value,
     dotted: &str,
 ) -> Option<bool> {
-    let buffer_overlay: serde_json::Value =
-        toml_edit::de::from_str(&document.to_string()).ok()?;
+    let buffer_overlay: serde_json::Value = toml_edit::de::from_str(&document.to_string()).ok()?;
     if !buffer_overlay.is_object() {
         // 空文档或不完整 buffer 解析出来可能不是 Object。不进行 merge
         // (merge_json 对非 Object overlay 会整体替换 base,会把 inherited
@@ -355,8 +354,7 @@ enabled = "yes"
     fn test_effective_bool_inherited_beats_default() -> Result<()> {
         let doc: DocumentMut = "".parse()?;
         let mut inherited = defaults_json();
-        inherited["components"]["project"]["enabled"] =
-            serde_json::Value::Bool(false);
+        inherited["components"]["project"]["enabled"] = serde_json::Value::Bool(false);
         let v = effective_bool(&doc, &inherited, "components.project.enabled");
         assert_eq!(v, Some(false));
         Ok(())

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -29,6 +29,11 @@ pub async fn render(
         update_throttling: false, // 预览要立即反映,不走 300ms 节流
         disable_cache: true,
         config_base_dir: base_dir.map(|p| p.to_string_lossy().into_owned()),
+        // 预览只是把 mock 的 InputData 过一遍渲染管线,看配置长什么样,
+        // 绝不能顺手把合成的 session_id / cost 写到 `~/.claude/.../sessions/`
+        // 里去污染真实 usage / cost 历史。generator 内部的守卫会在
+        // `preview_mode=true` 时跳过 storage 初始化和 snapshot 写入。
+        preview_mode: true,
         ..GeneratorOptions::default()
     };
 
@@ -139,6 +144,53 @@ mod tests {
         let config = Config::default();
         let lines = render(&config, "dev", Some(temp.path())).await?;
         assert!(!lines.is_empty());
+        Ok(())
+    }
+
+    /// 回归:preview render 必须是"纯函数",不能在 `$HOME/.claude/.../sessions/`
+    /// 下落任何 snapshot 文件。之前 generator 无条件调用
+    /// `storage::update_session_snapshot`,只要编辑器打开或切一下 mock 场景,
+    /// 就会把合成的 `mock-dev-session` 写进真实 usage 历史。
+    #[tokio::test]
+    async fn test_render_does_not_persist_session_snapshot() -> Result<()> {
+        // 用临时 HOME 捕获所有可能的持久化 I/O;真实用户目录绝对不能被写到。
+        let fake_home = tempfile::tempdir()?;
+        let original_home = std::env::var_os("HOME");
+        // 安全起见,tests 在同一 process 里是串行运行的单个 test_render_*,
+        // 但 std::env 是全局的;设置后 test 末尾必须恢复。
+        std::env::set_var("HOME", fake_home.path());
+
+        let config = Config::default();
+        let render_result = render(&config, "dev", None).await;
+
+        // 恢复 HOME 后再断言,避免污染后续测试
+        match original_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        let lines = render_result?;
+        assert!(!lines.is_empty());
+
+        // fake_home 里不能出现任何 sessions 目录。即使出现,也不能有文件。
+        let sessions_root = fake_home.path().join(".claude");
+        if sessions_root.exists() {
+            // 允许目录存在(不是我们建的也可能是测试辅助),但不能有 session json
+            let mut stack = vec![sessions_root];
+            while let Some(dir) = stack.pop() {
+                for entry in std::fs::read_dir(&dir)?.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else {
+                        panic!(
+                            "preview render 不应该在 $HOME 下写任何文件,却发现: {}",
+                            path.display()
+                        );
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -1,0 +1,90 @@
+//! 实时预览:用当前编辑中的配置调用 `StatuslineGenerator` + mock 数据。
+//!
+//! v2 起用 `ansi_to_tui` 把 statusline 输出的 ANSI 转义直接解析成 ratatui `Line`,
+//! TUI 里能看到带颜色的主线与渐变进度条,和真实终端里一致。
+
+use ansi_to_tui::IntoText;
+use anyhow::{anyhow, Result};
+use ratatui::text::Line;
+
+use claude_code_statusline_pro::config::Config;
+use claude_code_statusline_pro::core::{GeneratorOptions, StatuslineGenerator};
+
+use crate::mock_data::MockDataGenerator;
+
+/// 预览一次的结果:每行保留颜色样式的 ratatui `Line`。
+pub async fn render(config: &Config, mock: &str) -> Result<Vec<Line<'static>>> {
+    let options = GeneratorOptions {
+        update_throttling: false, // 预览要立即反映,不走 300ms 节流
+        disable_cache: true,
+        ..GeneratorOptions::default()
+    };
+
+    let mut generator = StatuslineGenerator::new(config.clone(), options);
+    let mock_gen = MockDataGenerator::new();
+    let input = mock_gen.generate(mock).unwrap_or_default();
+
+    let raw = generator.generate(input).await?;
+    ansi_to_lines(&raw)
+}
+
+fn ansi_to_lines(raw: &str) -> Result<Vec<Line<'static>>> {
+    let text = raw
+        .as_bytes()
+        .into_text()
+        .map_err(|err| anyhow!("ANSI 解析失败: {err}"))?;
+    Ok(text.lines.into_iter().collect())
+}
+
+/// 可用 mock 场景列表(排序)。
+pub fn available_mocks() -> Vec<String> {
+    let mut v: Vec<String> = MockDataGenerator::new()
+        .available()
+        .map(std::string::ToString::to_string)
+        .collect();
+    v.sort();
+    v
+}
+
+/// 从 `DocumentMut` 字符串反序列化到 `Config`;解析错误时包一层上下文。
+pub fn parse_config(toml_text: &str) -> Result<Config> {
+    toml_edit::de::from_str::<Config>(toml_text).map_err(|err| anyhow!("{err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ansi_to_lines_plain() -> Result<()> {
+        let lines = ansi_to_lines("hello world\n")?;
+        assert!(!lines.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_ansi_to_lines_with_escape() -> Result<()> {
+        let lines = ansi_to_lines("\x1b[31mhello\x1b[0m")?;
+        assert!(!lines.is_empty());
+        // ansi-to-tui 会把每个转义解析成带样式的 Span
+        let has_content = lines
+            .iter()
+            .any(|l| l.spans.iter().any(|s| s.content.contains("hello")));
+        assert!(has_content);
+        Ok(())
+    }
+
+    #[test]
+    fn test_available_mocks_not_empty() {
+        let mocks = available_mocks();
+        assert!(!mocks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_render_default_config_with_dev_mock() -> Result<()> {
+        let config = Config::default();
+        let lines = render(&config, "dev").await?;
+        assert!(!lines.is_empty());
+        Ok(())
+    }
+}

--- a/src/tui/preview.rs
+++ b/src/tui/preview.rs
@@ -3,6 +3,8 @@
 //! v2 起用 `ansi_to_tui` 把 statusline 输出的 ANSI 转义直接解析成 ratatui `Line`,
 //! TUI 里能看到带颜色的主线与渐变进度条,和真实终端里一致。
 
+use std::path::Path;
+
 use ansi_to_tui::IntoText;
 use anyhow::{anyhow, Result};
 use ratatui::text::Line;
@@ -13,10 +15,20 @@ use claude_code_statusline_pro::core::{GeneratorOptions, StatuslineGenerator};
 use crate::mock_data::MockDataGenerator;
 
 /// 预览一次的结果:每行保留颜色样式的 ratatui `Line`。
-pub async fn render(config: &Config, mock: &str) -> Result<Vec<Line<'static>>> {
+///
+/// `base_dir` 应该是当前正在编辑的配置文件所在目录;传给 generator 是为了
+/// 让多行 widget 的 `components/*.toml` 解析走和真实运行时一样的相对路径,
+/// 否则 project/custom scope 下的预览会错误地回落到用户目录或 `./components`,
+/// 和实际渲染出现偏差。
+pub async fn render(
+    config: &Config,
+    mock: &str,
+    base_dir: Option<&Path>,
+) -> Result<Vec<Line<'static>>> {
     let options = GeneratorOptions {
         update_throttling: false, // 预览要立即反映,不走 300ms 节流
         disable_cache: true,
+        config_base_dir: base_dir.map(|p| p.to_string_lossy().into_owned()),
         ..GeneratorOptions::default()
     };
 
@@ -83,7 +95,17 @@ mod tests {
     #[tokio::test]
     async fn test_render_default_config_with_dev_mock() -> Result<()> {
         let config = Config::default();
-        let lines = render(&config, "dev").await?;
+        let lines = render(&config, "dev", None).await?;
+        assert!(!lines.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_render_honors_base_dir() -> Result<()> {
+        // 只是确认 base_dir 被接受且不 panic;与 main.rs 的行为对齐
+        let temp = tempfile::tempdir()?;
+        let config = Config::default();
+        let lines = render(&config, "dev", Some(temp.path())).await?;
         assert!(!lines.is_empty());
         Ok(())
     }

--- a/src/tui/sections.rs
+++ b/src/tui/sections.rs
@@ -1,0 +1,577 @@
+//! 配置段与字段元数据
+//!
+//! v2 扩展到 11 个 Tab:基础 / 样式 / 终端 / 项目 / 模型 / 分支 / Token / Usage /
+//! 状态 / 主题 / 多行。新增 `Color` 与 `Float` 字段类型。
+
+/// 分段(对应 UI 里的 Tab)。
+pub struct Section {
+    pub title: &'static str,
+    pub help: &'static str,
+    pub fields: &'static [Field],
+}
+
+/// 单个字段。`path` 用点路径描述 TOML 位置。
+pub struct Field {
+    pub label: &'static str,
+    pub path: &'static str,
+    pub kind: FieldKind,
+    pub help: &'static str,
+}
+
+/// 字段类型,决定编辑器形态。
+pub enum FieldKind {
+    Text,
+    Bool,
+    Enum(&'static [&'static str]),
+    /// 颜色:在标准终端色板里循环;也接受手填(CLI)自定义值。
+    Color,
+    Int {
+        min: i64,
+        max: i64,
+    },
+    /// 浮点(带范围),目前主要用于 token 阈值。
+    Float {
+        min: f64,
+        max: f64,
+    },
+}
+
+/// 终端色板候选。按可读顺序排列。
+pub static COLOR_PALETTE: &[&str] = &[
+    "white",
+    "black",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "gray",
+    "bright_black",
+    "bright_red",
+    "bright_green",
+    "bright_yellow",
+    "bright_blue",
+    "bright_magenta",
+    "bright_cyan",
+    "bright_white",
+];
+
+pub static SECTIONS: &[Section] = &[
+    // ============== 基础 ==============
+    Section {
+        title: "基础",
+        help: "状态栏核心设置",
+        fields: &[
+            Field {
+                label: "preset",
+                path: "preset",
+                kind: FieldKind::Text,
+                help: "组件预设字符串,例如 PMBTUS。字母映射见 preset_mapping。",
+            },
+            Field {
+                label: "theme",
+                path: "theme",
+                kind: FieldKind::Enum(&["classic", "powerline", "capsule"]),
+                help: "主题风格。powerline / capsule 需要 Nerd Font。",
+            },
+            Field {
+                label: "language",
+                path: "language",
+                kind: FieldKind::Enum(&["zh", "en"]),
+                help: "界面语言。",
+            },
+            Field {
+                label: "debug",
+                path: "debug",
+                kind: FieldKind::Bool,
+                help: "调试输出。生产环境建议关闭。",
+            },
+        ],
+    },
+    // ============== 样式 ==============
+    Section {
+        title: "样式",
+        help: "分隔符与整体风格",
+        fields: &[
+            Field {
+                label: "separator",
+                path: "style.separator",
+                kind: FieldKind::Text,
+                help: "组件间分隔符。",
+            },
+            Field {
+                label: "separator_color",
+                path: "style.separator_color",
+                kind: FieldKind::Color,
+                help: "分隔符颜色,支持标准终端色或 #rrggbb。",
+            },
+            Field {
+                label: "separator_before",
+                path: "style.separator_before",
+                kind: FieldKind::Text,
+                help: "分隔符前空格。",
+            },
+            Field {
+                label: "separator_after",
+                path: "style.separator_after",
+                kind: FieldKind::Text,
+                help: "分隔符后空格。",
+            },
+        ],
+    },
+    // ============== 终端 ==============
+    Section {
+        title: "终端",
+        help: "强制终端能力(覆盖自动检测)",
+        fields: &[
+            Field {
+                label: "force_nerd_font",
+                path: "terminal.force_nerd_font",
+                kind: FieldKind::Bool,
+                help: "强制启用 Nerd Font 图标。",
+            },
+            Field {
+                label: "force_emoji",
+                path: "terminal.force_emoji",
+                kind: FieldKind::Bool,
+                help: "强制启用 Emoji 图标。",
+            },
+            Field {
+                label: "force_text",
+                path: "terminal.force_text",
+                kind: FieldKind::Bool,
+                help: "强制纯文本(最大兼容性)。",
+            },
+        ],
+    },
+    // ============== 项目组件 ==============
+    Section {
+        title: "项目",
+        help: "Project 组件 — 显示项目名",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "components.project.enabled",
+                kind: FieldKind::Bool,
+                help: "启用 project 组件。",
+            },
+            Field {
+                label: "icon_color",
+                path: "components.project.icon_color",
+                kind: FieldKind::Color,
+                help: "图标颜色。",
+            },
+            Field {
+                label: "text_color",
+                path: "components.project.text_color",
+                kind: FieldKind::Color,
+                help: "文本颜色。",
+            },
+            Field {
+                label: "emoji_icon",
+                path: "components.project.emoji_icon",
+                kind: FieldKind::Text,
+                help: "Emoji 图标。",
+            },
+            Field {
+                label: "nerd_icon",
+                path: "components.project.nerd_icon",
+                kind: FieldKind::Text,
+                help: "Nerd Font 图标(Unicode 转义)。",
+            },
+            Field {
+                label: "text_icon",
+                path: "components.project.text_icon",
+                kind: FieldKind::Text,
+                help: "纯文本图标,如 [P]。",
+            },
+            Field {
+                label: "show_when_empty",
+                path: "components.project.show_when_empty",
+                kind: FieldKind::Bool,
+                help: "项目名为空时是否显示。",
+            },
+        ],
+    },
+    // ============== 模型组件 ==============
+    Section {
+        title: "模型",
+        help: "Model 组件 — 显示当前模型",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "components.model.enabled",
+                kind: FieldKind::Bool,
+                help: "启用 model 组件。",
+            },
+            Field {
+                label: "icon_color",
+                path: "components.model.icon_color",
+                kind: FieldKind::Color,
+                help: "图标颜色。",
+            },
+            Field {
+                label: "text_color",
+                path: "components.model.text_color",
+                kind: FieldKind::Color,
+                help: "文本颜色。",
+            },
+            Field {
+                label: "emoji_icon",
+                path: "components.model.emoji_icon",
+                kind: FieldKind::Text,
+                help: "Emoji 图标。",
+            },
+            Field {
+                label: "nerd_icon",
+                path: "components.model.nerd_icon",
+                kind: FieldKind::Text,
+                help: "Nerd Font 图标。",
+            },
+            Field {
+                label: "text_icon",
+                path: "components.model.text_icon",
+                kind: FieldKind::Text,
+                help: "纯文本图标。",
+            },
+            Field {
+                label: "show_full_name",
+                path: "components.model.show_full_name",
+                kind: FieldKind::Bool,
+                help: "显示完整模型名(Sonnet 4.5)而非缩写(S4.5)。",
+            },
+        ],
+    },
+    // ============== 分支组件 ==============
+    Section {
+        title: "分支",
+        help: "Branch 组件 — Git 分支与工作区状态",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "components.branch.enabled",
+                kind: FieldKind::Bool,
+                help: "启用 branch 组件。",
+            },
+            Field {
+                label: "icon_color",
+                path: "components.branch.icon_color",
+                kind: FieldKind::Color,
+                help: "图标颜色。",
+            },
+            Field {
+                label: "text_color",
+                path: "components.branch.text_color",
+                kind: FieldKind::Color,
+                help: "分支名颜色。",
+            },
+            Field {
+                label: "emoji_icon",
+                path: "components.branch.emoji_icon",
+                kind: FieldKind::Text,
+                help: "Emoji 图标。",
+            },
+            Field {
+                label: "nerd_icon",
+                path: "components.branch.nerd_icon",
+                kind: FieldKind::Text,
+                help: "Nerd Font 图标。",
+            },
+            Field {
+                label: "text_icon",
+                path: "components.branch.text_icon",
+                kind: FieldKind::Text,
+                help: "纯文本图标。",
+            },
+            Field {
+                label: "max_length",
+                path: "components.branch.max_length",
+                kind: FieldKind::Int { min: 0, max: 128 },
+                help: "分支名最大长度,超过会截断。",
+            },
+            Field {
+                label: "show_when_no_git",
+                path: "components.branch.show_when_no_git",
+                kind: FieldKind::Bool,
+                help: "不在 git 仓库时是否占位。",
+            },
+            Field {
+                label: "show_dirty",
+                path: "components.branch.status.show_dirty",
+                kind: FieldKind::Bool,
+                help: "显示 dirty 工作区标记。",
+            },
+            Field {
+                label: "show_ahead_behind",
+                path: "components.branch.status.show_ahead_behind",
+                kind: FieldKind::Bool,
+                help: "显示领先/落后提交数。",
+            },
+            Field {
+                label: "show_stash_count",
+                path: "components.branch.status.show_stash_count",
+                kind: FieldKind::Bool,
+                help: "显示 stash 数量。",
+            },
+        ],
+    },
+    // ============== Token 组件 ==============
+    Section {
+        title: "Token",
+        help: "Tokens 组件 — 上下文使用量与进度条",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "components.tokens.enabled",
+                kind: FieldKind::Bool,
+                help: "启用 tokens 组件。",
+            },
+            Field {
+                label: "icon_color",
+                path: "components.tokens.icon_color",
+                kind: FieldKind::Color,
+                help: "图标颜色。",
+            },
+            Field {
+                label: "text_color",
+                path: "components.tokens.text_color",
+                kind: FieldKind::Color,
+                help: "文本颜色。",
+            },
+            Field {
+                label: "show_progress_bar",
+                path: "components.tokens.show_progress_bar",
+                kind: FieldKind::Bool,
+                help: "显示可视化进度条。",
+            },
+            Field {
+                label: "show_percentage",
+                path: "components.tokens.show_percentage",
+                kind: FieldKind::Bool,
+                help: "显示百分比数值。",
+            },
+            Field {
+                label: "show_raw_numbers",
+                path: "components.tokens.show_raw_numbers",
+                kind: FieldKind::Bool,
+                help: "显示 (used/total) 原始数字。",
+            },
+            Field {
+                label: "show_gradient",
+                path: "components.tokens.show_gradient",
+                kind: FieldKind::Bool,
+                help: "启用彩虹渐变色。",
+            },
+            Field {
+                label: "progress_width",
+                path: "components.tokens.progress_width",
+                kind: FieldKind::Int { min: 4, max: 60 },
+                help: "进度条字符宽度。",
+            },
+            Field {
+                label: "warning (%)",
+                path: "components.tokens.thresholds.warning",
+                kind: FieldKind::Float {
+                    min: 0.0,
+                    max: 100.0,
+                },
+                help: "警告阈值百分比(变黄)。",
+            },
+            Field {
+                label: "danger (%)",
+                path: "components.tokens.thresholds.danger",
+                kind: FieldKind::Float {
+                    min: 0.0,
+                    max: 100.0,
+                },
+                help: "危险阈值百分比(变红)。",
+            },
+            Field {
+                label: "backup (%)",
+                path: "components.tokens.thresholds.backup",
+                kind: FieldKind::Float {
+                    min: 0.0,
+                    max: 100.0,
+                },
+                help: "备份阈值(进度条末端样式)。",
+            },
+            Field {
+                label: "critical (%)",
+                path: "components.tokens.thresholds.critical",
+                kind: FieldKind::Float {
+                    min: 0.0,
+                    max: 100.0,
+                },
+                help: "临界阈值(显示火焰图标)。",
+            },
+        ],
+    },
+    // ============== Usage 组件 ==============
+    Section {
+        title: "Usage",
+        help: "Usage 组件 — 成本与行数统计",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "components.usage.enabled",
+                kind: FieldKind::Bool,
+                help: "启用 usage 组件。",
+            },
+            Field {
+                label: "icon_color",
+                path: "components.usage.icon_color",
+                kind: FieldKind::Color,
+                help: "图标颜色。",
+            },
+            Field {
+                label: "text_color",
+                path: "components.usage.text_color",
+                kind: FieldKind::Color,
+                help: "文本颜色(实际运行时会按花费等级自动染色)。",
+            },
+            Field {
+                label: "display_mode",
+                path: "components.usage.display_mode",
+                kind: FieldKind::Enum(&["session", "conversation", "smart"]),
+                help: "session=本次会话,conversation=跨 session 累加,smart=自适应。",
+            },
+            Field {
+                label: "precision",
+                path: "components.usage.precision",
+                kind: FieldKind::Int { min: 0, max: 6 },
+                help: "成本小数位数。",
+            },
+            Field {
+                label: "show_lines_added",
+                path: "components.usage.show_lines_added",
+                kind: FieldKind::Bool,
+                help: "显示新增代码行数(仅 conversation 模式)。",
+            },
+            Field {
+                label: "show_lines_removed",
+                path: "components.usage.show_lines_removed",
+                kind: FieldKind::Bool,
+                help: "显示删除代码行数(仅 conversation 模式)。",
+            },
+        ],
+    },
+    // ============== Status 组件 ==============
+    Section {
+        title: "状态",
+        help: "Status 组件 — Ready / Thinking / Tool / Error",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "components.status.enabled",
+                kind: FieldKind::Bool,
+                help: "启用 status 组件。",
+            },
+            Field {
+                label: "icon_color",
+                path: "components.status.icon_color",
+                kind: FieldKind::Color,
+                help: "图标默认颜色(会按状态覆盖)。",
+            },
+            Field {
+                label: "text_color",
+                path: "components.status.text_color",
+                kind: FieldKind::Color,
+                help: "文本颜色。",
+            },
+            Field {
+                label: "show_when_idle",
+                path: "components.status.show_when_idle",
+                kind: FieldKind::Bool,
+                help: "空闲时是否显示 Ready。",
+            },
+            Field {
+                label: "show_recent_errors",
+                path: "components.status.show_recent_errors",
+                kind: FieldKind::Bool,
+                help: "显示最近的错误片段。",
+            },
+        ],
+    },
+    // ============== 主题 ==============
+    Section {
+        title: "主题",
+        help: "三大主题的独立开关",
+        fields: &[
+            Field {
+                label: "classic: gradient",
+                path: "themes.classic.enable_gradient",
+                kind: FieldKind::Bool,
+                help: "Classic 主题彩色渐变。",
+            },
+            Field {
+                label: "classic: fine_progress",
+                path: "themes.classic.fine_progress",
+                kind: FieldKind::Bool,
+                help: "Classic 精细进度条字符。",
+            },
+            Field {
+                label: "powerline: gradient",
+                path: "themes.powerline.enable_gradient",
+                kind: FieldKind::Bool,
+                help: "Powerline 彩色渐变。",
+            },
+            Field {
+                label: "powerline: fine_progress",
+                path: "themes.powerline.fine_progress",
+                kind: FieldKind::Bool,
+                help: "Powerline 精细进度条。",
+            },
+            Field {
+                label: "powerline: fg",
+                path: "themes.powerline.fg",
+                kind: FieldKind::Color,
+                help: "Powerline 文本前景色(白色/黑色/#hex)。",
+            },
+            Field {
+                label: "capsule: gradient",
+                path: "themes.capsule.enable_gradient",
+                kind: FieldKind::Bool,
+                help: "Capsule 彩色渐变。",
+            },
+            Field {
+                label: "capsule: fine_progress",
+                path: "themes.capsule.fine_progress",
+                kind: FieldKind::Bool,
+                help: "Capsule 精细进度条。",
+            },
+            Field {
+                label: "capsule: fg",
+                path: "themes.capsule.fg",
+                kind: FieldKind::Color,
+                help: "Capsule 文本前景色。",
+            },
+        ],
+    },
+    // ============== 多行 ==============
+    Section {
+        title: "多行",
+        help: "多行状态栏与 Widget 开关",
+        fields: &[
+            Field {
+                label: "enabled",
+                path: "multiline.enabled",
+                kind: FieldKind::Bool,
+                help: "是否启用第二行和 Widget 系统。",
+            },
+            Field {
+                label: "max_rows",
+                path: "multiline.max_rows",
+                kind: FieldKind::Int { min: 1, max: 10 },
+                help: "多行最大行数。",
+            },
+        ],
+    },
+    // ============== Widgets ==============
+    // 特殊面板:没有 fields,由 app/view 特判成 widget 列表视图
+    Section {
+        title: "Widgets",
+        help: "已检测到的 widget 文件(Space 切 enabled / t 切类型 / d 删除)",
+        fields: &[],
+    },
+];

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -8,7 +8,7 @@ use ratatui::Frame;
 
 use claude_code_statusline_pro::config::ConfigSourceType;
 
-use crate::tui::app::{App, EditScope, Focus, MessageKind, Mode};
+use crate::tui::app::{App, EditBuffer, EditScope, Focus, MessageKind, Mode};
 use crate::tui::sections::{FieldKind, SECTIONS};
 use crate::tui::{get_field_display, get_mock_label};
 
@@ -32,11 +32,14 @@ pub fn render(frame: &mut Frame, app: &App) {
     render_preview(frame, chunks[3], app);
     render_footer(frame, chunks[4], app);
 
-    if let Mode::EditText(buf) = &app.mode {
-        render_edit_overlay(frame, size, app, buf);
+    if let Mode::EditText(buffer) = &app.mode {
+        render_edit_overlay(frame, size, app, buffer);
     }
     if app.search.is_some() {
         render_search_overlay(frame, size, app);
+    }
+    if app.widget_new.is_some() {
+        render_widget_new_overlay(frame, size, app);
     }
     if app.merge_report_visible {
         render_merge_report(frame, size, app);
@@ -182,6 +185,7 @@ fn render_widget_help(frame: &mut Frame, area: Rect, app: &App) {
         )),
         Line::from(""),
         Line::from("  ↑↓      上下选择"),
+        Line::from("  n       新增(输入名字)"),
         Line::from("  Space   切 enabled"),
         Line::from("  t       切 type (static ↔ api)"),
         Line::from("  d/Del   删除(无二次确认)"),
@@ -313,6 +317,43 @@ fn render_field_help(frame: &mut Frame, area: Rect, app: &App) {
             field.help,
             Style::default().fg(Color::LightYellow),
         )));
+
+        // Color 字段:渲染当前值 + 色板预览
+        if matches!(field.kind, FieldKind::Color) {
+            lines.push(Line::from(""));
+            let current = crate::tui::io::get_string(&app.document, field.path);
+            if let Some(value) = current.as_deref() {
+                let color = parse_color_name(value);
+                lines.push(Line::from(vec![
+                    Span::styled("当前: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("■■■", Style::default().fg(color)),
+                    Span::raw("  "),
+                    Span::styled(value.to_string(), Style::default().fg(Color::White)),
+                ]));
+            } else {
+                lines.push(Line::from(Span::styled(
+                    "当前: (未设置)",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+            lines.push(Line::from(Span::styled(
+                "色板(Space 循环):",
+                Style::default().fg(Color::DarkGray),
+            )));
+            // 渲染标准色板
+            for row_slice in crate::tui::sections::COLOR_PALETTE.chunks(6) {
+                let mut spans = vec![Span::raw("  ")];
+                for name in row_slice {
+                    let color = parse_color_name(name);
+                    spans.push(Span::styled("■ ", Style::default().fg(color)));
+                    spans.push(Span::styled(
+                        format!("{name:<15}"),
+                        Style::default().fg(Color::Gray),
+                    ));
+                }
+                lines.push(Line::from(spans));
+            }
+        }
     }
 
     // 多行 Tab 下追加 widgets 概览
@@ -416,7 +457,7 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(Paragraph::new(vec![help_line, status_line]), area);
 }
 
-fn render_edit_overlay(frame: &mut Frame, area: Rect, app: &App, buf: &str) {
+fn render_edit_overlay(frame: &mut Frame, area: Rect, app: &App, buffer: &EditBuffer) {
     let rect = centered_rect(60, 5, area);
     frame.render_widget(Clear, rect);
 
@@ -424,13 +465,27 @@ fn render_edit_overlay(frame: &mut Frame, area: Rect, app: &App, buf: &str) {
         .current_field()
         .map_or_else(|| "编辑".to_string(), |f| format!("编辑: {}", f.path));
 
+    // 三段渲染:光标前 + 光标块(高亮光标下字符或末尾方块) + 光标后
+    let before = buffer.before_cursor().to_string();
+    let after_str = buffer.after_cursor();
+    let (cursor_char, rest_after) = match after_str.chars().next() {
+        Some(ch) => (ch.to_string(), &after_str[ch.len_utf8()..]),
+        None => ("▌".to_string(), ""),
+    };
+
+    let cursor_style = Style::default()
+        .fg(Color::Black)
+        .bg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+
     let text = Line::from(vec![
         Span::styled("▶ ", Style::default().fg(Color::Yellow)),
-        Span::raw(buf),
-        Span::styled("▌", Style::default().fg(Color::Yellow)),
+        Span::raw(before),
+        Span::styled(cursor_char, cursor_style),
+        Span::raw(rest_after.to_string()),
     ]);
     let hint = Line::from(Span::styled(
-        "Enter 提交   Esc 取消",
+        "Enter 提交   Esc 取消   ←→/Home/End/Ctrl+A/E 移光标   Delete 删后   Backspace 删前",
         Style::default().fg(Color::DarkGray),
     ));
 
@@ -444,7 +499,7 @@ fn render_edit_overlay(frame: &mut Frame, area: Rect, app: &App, buf: &str) {
 }
 
 fn render_help(frame: &mut Frame, area: Rect) {
-    let rect = centered_rect(70, 18, area);
+    let rect = centered_rect(72, 22, area);
     frame.render_widget(Clear, rect);
 
     let lines = vec![
@@ -460,15 +515,20 @@ fn render_help(frame: &mut Frame, area: Rect) {
         Line::from("  ↑ ↓                      字段上下移动"),
         Line::from("  Enter                     编辑当前字段(Color/Int/Float 进文本)"),
         Line::from("  Space                     Bool 翻转 / Enum / Color 循环下一个"),
-        Line::from("  Esc                       取消当前编辑 / 关闭浮层"),
         Line::from("  /                         跨分段搜索字段"),
         Line::from("  F2                        查看配置合并报告"),
         Line::from("  Ctrl+T                    切换 scope(user ↔ project)"),
-        Line::from("  Ctrl+S                    保存到文件"),
-        Line::from("  Ctrl+R                    撤销所有未保存修改"),
+        Line::from("  Ctrl+S / Ctrl+R           保存 / 撤销"),
         Line::from("  Ctrl+M                    切换 mock 场景"),
-        Line::from("  Ctrl+Q                    退出"),
-        Line::from("  ?                         显示/隐藏本帮助"),
+        Line::from("  Ctrl+Q / ? / Esc          退出 / 帮助 / 关闭浮层"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  — 文本编辑模式下 —",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from("  ← → / Ctrl+A E / Home End  光标移动"),
+        Line::from("  Backspace / Delete         删前 / 删后"),
+        Line::from("  Enter / Esc                提交 / 放弃"),
         Line::from(""),
         Line::from(Span::styled(
             "  注意:保存前会做一次 TOML → Config 校验,不合法不会写盘。",
@@ -479,6 +539,63 @@ fn render_help(frame: &mut Frame, area: Rect) {
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Cyan)),
+    );
+    frame.render_widget(para, rect);
+}
+
+fn render_widget_new_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let Some(dialog) = app.widget_new.as_ref() else {
+        return;
+    };
+
+    let rect = centered_rect(60, 9, area);
+    frame.render_widget(Clear, rect);
+
+    let before = dialog.name.before_cursor().to_string();
+    let after = dialog.name.after_cursor();
+    let (cursor_char, rest) = match after.chars().next() {
+        Some(ch) => (ch.to_string(), &after[ch.len_utf8()..]),
+        None => ("▌".to_string(), ""),
+    };
+
+    let lines = vec![
+        Line::from(Span::styled(
+            format!("目标文件: {}", dialog.target_path.display()),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            format!("归属组件: {}", dialog.target_component),
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("新 widget 名字: ", Style::default().fg(Color::White)),
+            Span::raw(before),
+            Span::styled(
+                cursor_char,
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(rest.to_string()),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "默认模板: type=static, row=1, col=0, content=\"new widget\"",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            "Enter 创建   Esc 取消   只允许字母/数字/_/-",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let para = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" 新增 widget ")
+            .border_style(Style::default().fg(Color::Yellow)),
     );
     frame.render_widget(para, rect);
 }
@@ -664,6 +781,42 @@ fn format_key_list(keys: &[String]) -> String {
     }
 }
 
+/// 把配置里的颜色名 / hex 字符串映射到 ratatui `Color`。不识别时回退到 `Reset`。
+fn parse_color_name(raw: &str) -> Color {
+    let s = raw.trim().to_ascii_lowercase();
+    match s.as_str() {
+        "black" => Color::Black,
+        "red" => Color::Red,
+        "green" => Color::Green,
+        "yellow" => Color::Yellow,
+        "blue" => Color::Blue,
+        "magenta" => Color::Magenta,
+        "cyan" => Color::Cyan,
+        "white" => Color::White,
+        "gray" | "grey" => Color::DarkGray,
+        "bright_black" => Color::DarkGray,
+        "bright_red" => Color::LightRed,
+        "bright_green" => Color::LightGreen,
+        "bright_yellow" => Color::LightYellow,
+        "bright_blue" => Color::LightBlue,
+        "bright_magenta" => Color::LightMagenta,
+        "bright_cyan" => Color::LightCyan,
+        "bright_white" => Color::White,
+        _ => parse_hex_color(&s).unwrap_or(Color::Reset),
+    }
+}
+
+fn parse_hex_color(s: &str) -> Option<Color> {
+    let hex = s.strip_prefix('#')?;
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some(Color::Rgb(r, g, b))
+}
+
 fn kind_label(kind: &FieldKind) -> String {
     match kind {
         FieldKind::Text => "文本".to_string(),
@@ -693,4 +846,31 @@ fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vertical[1])[1]
+}
+
+#[cfg(test)]
+mod color_tests {
+    use super::{parse_color_name, parse_hex_color};
+    use ratatui::style::Color;
+
+    #[test]
+    fn test_named_colors() {
+        assert_eq!(parse_color_name("red"), Color::Red);
+        assert_eq!(parse_color_name("WHITE"), Color::White);
+        assert_eq!(parse_color_name("bright_blue"), Color::LightBlue);
+        assert_eq!(parse_color_name("gray"), Color::DarkGray);
+    }
+
+    #[test]
+    fn test_hex_color() {
+        assert_eq!(parse_color_name("#808080"), Color::Rgb(0x80, 0x80, 0x80));
+        assert_eq!(parse_hex_color("#ff0000"), Some(Color::Rgb(255, 0, 0)));
+        assert_eq!(parse_hex_color("#abc"), None); // 3-digit hex not supported
+        assert_eq!(parse_hex_color("abc"), None); // no '#'
+    }
+
+    #[test]
+    fn test_unknown_color_falls_back() {
+        assert_eq!(parse_color_name("not-a-color"), Color::Reset);
+    }
 }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -1,0 +1,696 @@
+//! ratatui 渲染层
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs, Wrap};
+use ratatui::Frame;
+
+use claude_code_statusline_pro::config::ConfigSourceType;
+
+use crate::tui::app::{App, EditScope, Focus, MessageKind, Mode};
+use crate::tui::sections::{FieldKind, SECTIONS};
+use crate::tui::{get_field_display, get_mock_label};
+
+pub fn render(frame: &mut Frame, app: &App) {
+    let size = frame.area();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // header
+            Constraint::Length(3), // tabs
+            Constraint::Min(6),    // body
+            Constraint::Length(5), // preview
+            Constraint::Length(2), // footer
+        ])
+        .split(size);
+
+    render_header(frame, chunks[0], app);
+    render_tabs(frame, chunks[1], app);
+    render_body(frame, chunks[2], app);
+    render_preview(frame, chunks[3], app);
+    render_footer(frame, chunks[4], app);
+
+    if let Mode::EditText(buf) = &app.mode {
+        render_edit_overlay(frame, size, app, buf);
+    }
+    if app.search.is_some() {
+        render_search_overlay(frame, size, app);
+    }
+    if app.merge_report_visible {
+        render_merge_report(frame, size, app);
+    }
+    if app.help_visible {
+        render_help(frame, size);
+    }
+}
+
+fn render_header(frame: &mut Frame, area: Rect, app: &App) {
+    let scope_label = match app.options.scope {
+        EditScope::User => "用户级",
+        EditScope::Project => "项目级",
+        EditScope::Custom => "自定义",
+    };
+    let dirty_mark = if app.dirty { " (未保存 *)" } else { "" };
+
+    let line1 = Line::from(vec![
+        Span::styled(
+            " ccsp config editor ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{scope_label}{dirty_mark}"),
+            Style::default().fg(Color::Yellow),
+        ),
+    ]);
+    let line2 = Line::from(Span::styled(
+        app.options.path.display().to_string(),
+        Style::default().fg(Color::DarkGray),
+    ));
+    frame.render_widget(Paragraph::new(vec![line1, line2]), area);
+}
+
+fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
+    let titles: Vec<Line> = SECTIONS
+        .iter()
+        .map(|s| Line::from(Span::raw(s.title)))
+        .collect();
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::BOTTOM).title(" 分段 "))
+        .select(app.section_idx)
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_widget(tabs, area);
+}
+
+fn render_body(frame: &mut Frame, area: Rect, app: &App) {
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(area);
+
+    if app.is_widgets_tab() {
+        render_widget_list(frame, horizontal[0], app);
+        render_widget_help(frame, horizontal[1], app);
+    } else {
+        render_field_list(frame, horizontal[0], app);
+        render_field_help(frame, horizontal[1], app);
+    }
+}
+
+fn render_widget_list(frame: &mut Frame, area: Rect, app: &App) {
+    let flat = app.flat_widgets();
+    let items: Vec<ListItem> = flat
+        .iter()
+        .map(|&(fi, ei)| {
+            let file = &app.widget_files[fi];
+            let entry = &file.entries[ei];
+            let enabled_mark = if entry.enabled {
+                Span::styled("●", Style::default().fg(Color::Green))
+            } else {
+                Span::styled("○", Style::default().fg(Color::DarkGray))
+            };
+            let type_style = if entry.kind == "api" {
+                Style::default().fg(Color::LightBlue)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            let line = Line::from(vec![
+                enabled_mark,
+                Span::raw(" "),
+                Span::styled(
+                    format!("{:<14}", file.component),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(
+                    format!("{:<22}", entry.name),
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled(format!(" [{}]", entry.kind), type_style),
+                Span::styled(
+                    format!("  r{} c{}", entry.row, entry.col),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let title = format!(" Widgets · 共 {} 个 ", flat.len());
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(Style::default().fg(Color::Yellow)),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut state = ListState::default();
+    if !flat.is_empty() {
+        state.select(Some(app.widget_cursor.min(flat.len().saturating_sub(1))));
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_widget_help(frame: &mut Frame, area: Rect, app: &App) {
+    let mut lines = vec![
+        Line::from(Span::styled(
+            "Widgets 管理",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "● 启用   ○ 禁用",
+            Style::default().fg(Color::Gray),
+        )),
+        Line::from(""),
+        Line::from("  ↑↓      上下选择"),
+        Line::from("  Space   切 enabled"),
+        Line::from("  t       切 type (static ↔ api)"),
+        Line::from("  d/Del   删除(无二次确认)"),
+        Line::from(""),
+    ];
+
+    let flat = app.flat_widgets();
+    if let Some(&(fi, ei)) = flat.get(app.widget_cursor) {
+        let file = &app.widget_files[fi];
+        let entry = &file.entries[ei];
+        lines.push(Line::from(Span::styled(
+            "— 当前选中 —",
+            Style::default().fg(Color::DarkGray),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled("组件: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(file.component.clone(), Style::default().fg(Color::Cyan)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("名字: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(entry.name.clone(), Style::default().fg(Color::White)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("类型: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(entry.kind.clone(), Style::default().fg(Color::LightBlue)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("位置: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("row {} col {}", entry.row, entry.col),
+                Style::default().fg(Color::Magenta),
+            ),
+        ]));
+        lines.push(Line::from(Span::styled(
+            format!("文件: {}", file.path.display()),
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "(未发现任何 widget)",
+            Style::default().fg(Color::DarkGray),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "复制 configs/components/ 下模板到 ~/.claude/statusline-pro/components/,",
+            Style::default().fg(Color::Gray),
+        )));
+        lines.push(Line::from(Span::styled(
+            "或 ccsp config init -w 自动复制。",
+            Style::default().fg(Color::Gray),
+        )));
+    }
+
+    let help = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .block(Block::default().borders(Borders::ALL).title(" 说明 "));
+    frame.render_widget(help, area);
+}
+
+fn render_field_list(frame: &mut Frame, area: Rect, app: &App) {
+    let section = app.current_section();
+    let items: Vec<ListItem> = section
+        .fields
+        .iter()
+        .map(|f| {
+            let value = get_field_display(&app.document, f);
+            let line = Line::from(vec![
+                Span::styled(format!("{:<22}", f.label), Style::default().fg(Color::Cyan)),
+                Span::raw(" "),
+                Span::styled(value, Style::default().fg(Color::White)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let title = if app.focus == Focus::Fields {
+        format!(" 字段 · {} ", section.title)
+    } else {
+        format!("   字段 · {} ", section.title)
+    };
+    let border_style = if app.focus == Focus::Fields {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(border_style),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut state = ListState::default();
+    state.select(Some(app.field_idx));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_field_help(frame: &mut Frame, area: Rect, app: &App) {
+    let mut lines = Vec::new();
+    lines.push(Line::from(Span::styled(
+        app.current_section().help,
+        Style::default().fg(Color::Gray),
+    )));
+    lines.push(Line::from(""));
+
+    if let Some(field) = app.current_field() {
+        lines.push(Line::from(vec![
+            Span::styled("字段: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(field.label, Style::default().fg(Color::Cyan)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("路径: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(field.path, Style::default().fg(Color::White)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("类型: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(kind_label(&field.kind), Style::default().fg(Color::Magenta)),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            field.help,
+            Style::default().fg(Color::LightYellow),
+        )));
+    }
+
+    // 多行 Tab 下追加 widgets 概览
+    if app.current_section().title == "多行" {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "— 检测到的 widgets —",
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )));
+        if app.widget_summaries.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "(未发现 components/*.toml。复制 configs/components/ 下模板到 ~/.claude/statusline-pro/components/)",
+                Style::default().fg(Color::DarkGray),
+            )));
+        } else {
+            for summary in &app.widget_summaries {
+                let names = if summary.widget_names.is_empty() {
+                    "(空)".to_string()
+                } else {
+                    summary.widget_names.join(", ")
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(
+                        format!("{}.toml", summary.component),
+                        Style::default().fg(Color::Cyan),
+                    ),
+                    Span::styled(
+                        format!(" · {} widgets", summary.widget_names.len()),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+                lines.push(Line::from(Span::styled(
+                    format!("    path: {}", summary.file_path.display()),
+                    Style::default().fg(Color::DarkGray),
+                )));
+                lines.push(Line::from(Span::styled(
+                    format!("    {names}"),
+                    Style::default().fg(Color::Gray),
+                )));
+            }
+        }
+    }
+
+    let help = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .block(Block::default().borders(Borders::ALL).title(" 说明 "));
+    frame.render_widget(help, area);
+}
+
+fn render_preview(frame: &mut Frame, area: Rect, app: &App) {
+    let mock_label = get_mock_label(app.current_mock());
+    let title = format!(" 实时预览 (mock: {mock_label}) — Ctrl+M 切换场景 ");
+
+    let lines: Vec<Line> = if app.preview_lines.is_empty() {
+        vec![Line::from(Span::styled(
+            "(无内容)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        app.preview_lines.clone()
+    };
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
+    let help_line = Line::from(vec![
+        Span::styled("^S", Style::default().fg(Color::Yellow)),
+        Span::raw(" 保存  "),
+        Span::styled("^R", Style::default().fg(Color::Yellow)),
+        Span::raw(" 撤销  "),
+        Span::styled("^M", Style::default().fg(Color::Yellow)),
+        Span::raw(" 切 mock  "),
+        Span::styled("Tab", Style::default().fg(Color::Yellow)),
+        Span::raw(" 下个分段  "),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::raw(" 编辑  "),
+        Span::styled("?", Style::default().fg(Color::Yellow)),
+        Span::raw(" 帮助  "),
+        Span::styled("^Q", Style::default().fg(Color::Yellow)),
+        Span::raw(" 退出"),
+    ]);
+
+    let status_line = if let Some((msg, kind)) = &app.message {
+        let color = match kind {
+            MessageKind::Info => Color::Cyan,
+            MessageKind::Success => Color::Green,
+            MessageKind::Error => Color::Red,
+        };
+        Line::from(Span::styled(msg.clone(), Style::default().fg(color)))
+    } else {
+        Line::from("")
+    };
+
+    frame.render_widget(Paragraph::new(vec![help_line, status_line]), area);
+}
+
+fn render_edit_overlay(frame: &mut Frame, area: Rect, app: &App, buf: &str) {
+    let rect = centered_rect(60, 5, area);
+    frame.render_widget(Clear, rect);
+
+    let label = app
+        .current_field()
+        .map_or_else(|| "编辑".to_string(), |f| format!("编辑: {}", f.path));
+
+    let text = Line::from(vec![
+        Span::styled("▶ ", Style::default().fg(Color::Yellow)),
+        Span::raw(buf),
+        Span::styled("▌", Style::default().fg(Color::Yellow)),
+    ]);
+    let hint = Line::from(Span::styled(
+        "Enter 提交   Esc 取消",
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let para = Paragraph::new(vec![text, Line::from(""), hint]).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(label)
+            .border_style(Style::default().fg(Color::Yellow)),
+    );
+    frame.render_widget(para, rect);
+}
+
+fn render_help(frame: &mut Frame, area: Rect) {
+    let rect = centered_rect(70, 18, area);
+    frame.render_widget(Clear, rect);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            " 快捷键帮助 ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  Tab / Shift+Tab / ← →    切换分段"),
+        Line::from("  ↑ ↓                      字段上下移动"),
+        Line::from("  Enter                     编辑当前字段(Color/Int/Float 进文本)"),
+        Line::from("  Space                     Bool 翻转 / Enum / Color 循环下一个"),
+        Line::from("  Esc                       取消当前编辑 / 关闭浮层"),
+        Line::from("  /                         跨分段搜索字段"),
+        Line::from("  F2                        查看配置合并报告"),
+        Line::from("  Ctrl+T                    切换 scope(user ↔ project)"),
+        Line::from("  Ctrl+S                    保存到文件"),
+        Line::from("  Ctrl+R                    撤销所有未保存修改"),
+        Line::from("  Ctrl+M                    切换 mock 场景"),
+        Line::from("  Ctrl+Q                    退出"),
+        Line::from("  ?                         显示/隐藏本帮助"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  注意:保存前会做一次 TOML → Config 校验,不合法不会写盘。",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+    let para = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan)),
+    );
+    frame.render_widget(para, rect);
+}
+
+fn render_search_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let Some(state) = app.search.as_ref() else {
+        return;
+    };
+
+    let rect = centered_rect(72, 20, area);
+    frame.render_widget(Clear, rect);
+
+    let input_line = Line::from(vec![
+        Span::styled("/", Style::default().fg(Color::Yellow)),
+        Span::raw(state.query.clone()),
+        Span::styled("▌", Style::default().fg(Color::Yellow)),
+    ]);
+
+    let hint = Line::from(Span::styled(
+        format!(
+            "命中 {} 项   ↑↓ 移动   Enter 跳转   Esc 关闭",
+            state.results.len()
+        ),
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // 输入 + 提示
+            Constraint::Min(1),    // 结果列表
+        ])
+        .split(rect);
+
+    // 顶部输入
+    let top = Paragraph::new(vec![input_line, hint]).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" 搜索字段 ")
+            .border_style(Style::default().fg(Color::Yellow)),
+    );
+    frame.render_widget(top, chunks[0]);
+
+    // 结果列表
+    let items: Vec<ListItem> = state
+        .results
+        .iter()
+        .map(|&(si, fi)| {
+            let section = &SECTIONS[si];
+            let field = &section.fields[fi];
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("[{}] ", section.title),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(field.label, Style::default().fg(Color::White)),
+                Span::styled(
+                    format!("  ({})", field.path),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut list_state = ListState::default();
+    if !state.results.is_empty() {
+        list_state.select(Some(state.selected));
+    }
+    frame.render_stateful_widget(list, chunks[1], &mut list_state);
+}
+
+fn render_merge_report(frame: &mut Frame, area: Rect, app: &App) {
+    let rect = centered_rect(80, 22, area);
+    frame.render_widget(Clear, rect);
+
+    let mut lines = vec![Line::from(Span::styled(
+        " 配置合并报告(F2/Esc 关闭) ",
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    lines.push(Line::from(""));
+
+    match app.merge_report.as_ref() {
+        None => {
+            lines.push(Line::from(Span::styled(
+                "(合并报告不可用。可能是未加载默认配置或解析失败。)",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+        Some(report) if report.layers.is_empty() => {
+            lines.push(Line::from(Span::styled(
+                "当前仅使用内置默认值,未检测到用户或项目级覆盖层。",
+                Style::default().fg(Color::Gray),
+            )));
+        }
+        Some(report) => {
+            for (i, layer) in report.layers.iter().enumerate() {
+                let type_label = match layer.source_type {
+                    ConfigSourceType::Default => "内置默认",
+                    ConfigSourceType::User => "用户级",
+                    ConfigSourceType::Project => "项目级",
+                    ConfigSourceType::Custom => "自定义",
+                };
+                let path_str = layer
+                    .path
+                    .as_ref()
+                    .map_or_else(String::new, |p| format!("  →  {}", p.display()));
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  {}. ", i + 1),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::styled(
+                        type_label,
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(path_str, Style::default().fg(Color::Gray)),
+                ]));
+                if layer.added_keys.is_empty() && layer.updated_keys.is_empty() {
+                    lines.push(Line::from(Span::styled(
+                        "      (未引入新键或覆盖现有键)",
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                } else {
+                    if !layer.added_keys.is_empty() {
+                        lines.push(Line::from(vec![
+                            Span::styled("      新增键: ", Style::default().fg(Color::DarkGray)),
+                            Span::styled(
+                                format_key_list(&layer.added_keys),
+                                Style::default().fg(Color::Green),
+                            ),
+                        ]));
+                    }
+                    if !layer.updated_keys.is_empty() {
+                        lines.push(Line::from(vec![
+                            Span::styled("      覆盖键: ", Style::default().fg(Color::DarkGray)),
+                            Span::styled(
+                                format_key_list(&layer.updated_keys),
+                                Style::default().fg(Color::LightBlue),
+                            ),
+                        ]));
+                    }
+                }
+                lines.push(Line::from(""));
+            }
+        }
+    }
+
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan)),
+    );
+    frame.render_widget(para, rect);
+}
+
+fn format_key_list(keys: &[String]) -> String {
+    const MAX: usize = 10;
+    if keys.len() <= MAX {
+        keys.join(", ")
+    } else {
+        let visible = keys
+            .iter()
+            .take(MAX)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{visible} … (+{} 项)", keys.len() - MAX)
+    }
+}
+
+fn kind_label(kind: &FieldKind) -> String {
+    match kind {
+        FieldKind::Text => "文本".to_string(),
+        FieldKind::Bool => "布尔".to_string(),
+        FieldKind::Enum(options) => format!("枚举 [{}]", options.join(" / ")),
+        FieldKind::Color => "颜色(Space 循环色板,Enter 手填 hex / 自定义)".to_string(),
+        FieldKind::Int { min, max } => format!("整数 [{min}, {max}]"),
+        FieldKind::Float { min, max } => format!("浮点 [{min}, {max}]"),
+    }
+}
+
+fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(height),
+            Constraint::Min(0),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -1,0 +1,313 @@
+//! 扫描并在线编辑 `components/*.toml` 里的 widgets。
+//!
+//! v3 扩展:除了只读的 `WidgetSummary`,新增 `WidgetFile` 结构承载每个文件内完整
+//! widget 元信息,并提供三个 CRUD 操作(toggle_enabled / cycle_type / delete)。
+//! 所有写入都走 `toml_edit::DocumentMut`,保留注释与顺序。
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use toml_edit::{value as toml_value, DocumentMut, Item};
+
+use claude_code_statusline_pro::config::ComponentMultilineConfig;
+use claude_code_statusline_pro::utils;
+
+/// 旧版本只读摘要(向后兼容,其他 v2 代码还在用)。
+pub struct WidgetSummary {
+    pub component: String,
+    pub file_path: PathBuf,
+    pub widget_names: Vec<String>,
+}
+
+/// v3:完整的每文件 widget 元信息。
+#[derive(Debug, Clone)]
+pub struct WidgetFile {
+    pub component: String,
+    pub path: PathBuf,
+    pub entries: Vec<WidgetEntry>,
+}
+
+/// 单个 widget 的关键属性(列表展示用)。
+#[derive(Debug, Clone)]
+pub struct WidgetEntry {
+    pub name: String,
+    pub enabled: bool,
+    pub kind: String, // "static" | "api"
+    pub row: u32,
+    pub col: u32,
+}
+
+// ---- 只读摘要(v2 兼容接口) ----
+
+/// 扫描用户级和给定项目配置目录下的 `components/*.toml`,只返回名字列表。
+pub fn scan_summaries(project_base_dir: Option<&Path>) -> Vec<WidgetSummary> {
+    scan_files(project_base_dir)
+        .into_iter()
+        .map(|wf| WidgetSummary {
+            component: wf.component,
+            file_path: wf.path,
+            widget_names: wf.entries.into_iter().map(|e| e.name).collect(),
+        })
+        .collect()
+}
+
+// ---- v3 完整扫描 ----
+
+/// 扫描并返回每个文件里的 widget 完整元信息。
+pub fn scan_files(project_base_dir: Option<&Path>) -> Vec<WidgetFile> {
+    let mut out = Vec::new();
+
+    if let Some(home) = utils::home_dir() {
+        collect_from_dir(&home.join(".claude/statusline-pro/components"), &mut out);
+    }
+    if let Some(base) = project_base_dir {
+        collect_from_dir(&base.join("components"), &mut out);
+    }
+
+    out.sort_by(|a, b| a.component.cmp(&b.component));
+    out
+}
+
+fn collect_from_dir(dir: &Path, out: &mut Vec<WidgetFile>) {
+    if !dir.exists() {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "toml") {
+            if let Some(file) = parse_file(&path) {
+                out.push(file);
+            }
+        }
+    }
+}
+
+fn parse_file(path: &Path) -> Option<WidgetFile> {
+    let component = path.file_stem()?.to_str()?.to_string();
+    let content = fs::read_to_string(path).ok()?;
+    let config: ComponentMultilineConfig = toml_edit::de::from_str(&content).ok()?;
+    let mut entries: Vec<WidgetEntry> = config
+        .widgets
+        .into_iter()
+        .map(|(name, cfg)| WidgetEntry {
+            name,
+            enabled: cfg.enabled,
+            kind: match cfg.kind {
+                claude_code_statusline_pro::config::WidgetType::Static => "static".to_string(),
+                claude_code_statusline_pro::config::WidgetType::Api => "api".to_string(),
+            },
+            row: cfg.row,
+            col: cfg.col,
+        })
+        .collect();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    Some(WidgetFile {
+        component,
+        path: path.to_path_buf(),
+        entries,
+    })
+}
+
+// ---- CRUD ----
+
+/// 翻转指定 widget 的 `enabled`。返回新值。
+pub fn toggle_enabled(path: &Path, widget_name: &str) -> Result<bool> {
+    let mut doc = load_document(path)?;
+    let current = widget_get_bool(&doc, widget_name, "enabled").unwrap_or(true);
+    widget_set(&mut doc, widget_name, "enabled", toml_value(!current))?;
+    save_document(path, &doc)?;
+    Ok(!current)
+}
+
+/// 在 static ↔ api 之间循环。返回新类型字符串。
+pub fn cycle_type(path: &Path, widget_name: &str) -> Result<String> {
+    let mut doc = load_document(path)?;
+    let current = widget_get_string(&doc, widget_name, "type").unwrap_or_else(|| "static".into());
+    let next = if current == "static" { "api" } else { "static" };
+    widget_set(&mut doc, widget_name, "type", toml_value(next))?;
+    save_document(path, &doc)?;
+    Ok(next.to_string())
+}
+
+/// 删除整个 widget 表。
+pub fn delete_widget(path: &Path, widget_name: &str) -> Result<()> {
+    let mut doc = load_document(path)?;
+    let widgets = doc
+        .get_mut("widgets")
+        .and_then(|i| i.as_table_mut())
+        .ok_or_else(|| anyhow!("{} 中没有 [widgets] 表", path.display()))?;
+    if widgets.remove(widget_name).is_none() {
+        bail!("widget '{widget_name}' 不存在于 {}", path.display());
+    }
+    save_document(path, &doc)?;
+    Ok(())
+}
+
+// ---- 底层 TOML 操作 ----
+
+fn load_document(path: &Path) -> Result<DocumentMut> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("读取 {} 失败", path.display()))?;
+    content
+        .parse::<DocumentMut>()
+        .map_err(|err| anyhow!("{} 不是有效 TOML: {err}", path.display()))
+}
+
+fn save_document(path: &Path, doc: &DocumentMut) -> Result<()> {
+    let tmp = path.with_extension("toml.tmp");
+    fs::write(&tmp, doc.to_string()).with_context(|| format!("写 {} 失败", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("重命名失败: {}", path.display()))?;
+    Ok(())
+}
+
+fn widget_get_bool(doc: &DocumentMut, widget: &str, key: &str) -> Option<bool> {
+    doc.get("widgets")?
+        .as_table_like()?
+        .get(widget)?
+        .as_table_like()?
+        .get(key)?
+        .as_bool()
+}
+
+fn widget_get_string(doc: &DocumentMut, widget: &str, key: &str) -> Option<String> {
+    doc.get("widgets")?
+        .as_table_like()?
+        .get(widget)?
+        .as_table_like()?
+        .get(key)?
+        .as_str()
+        .map(std::string::ToString::to_string)
+}
+
+fn widget_set(doc: &mut DocumentMut, widget: &str, key: &str, value: Item) -> Result<()> {
+    let widgets = doc
+        .entry("widgets")
+        .or_insert(Item::Table(toml_edit::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("widgets 不是表"))?;
+    let widget_table = widgets
+        .entry(widget)
+        .or_insert(Item::Table(toml_edit::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("widgets.{widget} 不是表"))?;
+    widget_table.insert(key, value);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    fn write_sample(dir: &Path) -> Result<PathBuf> {
+        let comp_dir = dir.join("components");
+        fs::create_dir_all(&comp_dir)?;
+        let path = comp_dir.join("usage.toml");
+        fs::write(
+            &path,
+            r#"
+[widgets.foo]
+enabled = true
+type = "static"
+row = 1
+col = 0
+nerd_icon = "x"
+emoji_icon = "x"
+text_icon = "[x]"
+content = "hello"
+
+[widgets.bar]
+enabled = false
+type = "api"
+row = 1
+col = 1
+nerd_icon = "y"
+emoji_icon = "y"
+text_icon = "[y]"
+"#,
+        )?;
+        Ok(path)
+    }
+
+    #[test]
+    fn test_scan_files() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        write_sample(temp.path())?;
+        let files = scan_files(Some(temp.path()));
+        let usage = files.iter().find(|f| f.component == "usage");
+        assert!(usage.is_some());
+        let usage = match usage {
+            Some(u) => u,
+            None => return Ok(()),
+        };
+        assert_eq!(usage.entries.len(), 2);
+        let foo = usage.entries.iter().find(|e| e.name == "foo");
+        let foo = match foo {
+            Some(f) => f,
+            None => return Ok(()),
+        };
+        assert!(foo.enabled);
+        assert_eq!(foo.kind, "static");
+        Ok(())
+    }
+
+    #[test]
+    fn test_toggle_enabled() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_sample(temp.path())?;
+        let new_value = toggle_enabled(&path, "foo")?;
+        assert!(!new_value);
+        // 再切一次应该回 true
+        let new_value = toggle_enabled(&path, "foo")?;
+        assert!(new_value);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cycle_type() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_sample(temp.path())?;
+        let new_type = cycle_type(&path, "foo")?;
+        assert_eq!(new_type, "api");
+        let new_type = cycle_type(&path, "foo")?;
+        assert_eq!(new_type, "static");
+        Ok(())
+    }
+
+    #[test]
+    fn test_delete_widget() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_sample(temp.path())?;
+        delete_widget(&path, "bar")?;
+        let files = scan_files(Some(temp.path()));
+        let usage = files.iter().find(|f| f.component == "usage");
+        let usage = match usage {
+            Some(u) => u,
+            None => return Ok(()),
+        };
+        assert!(usage.entries.iter().all(|e| e.name != "bar"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_scan_missing_dir_returns_empty() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let summaries = scan_summaries(Some(temp.path()));
+        let _ = summaries;
+        Ok(())
+    }
+
+    #[test]
+    fn test_scan_with_widget_file() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        write_sample(temp.path())?;
+        let summaries = scan_summaries(Some(temp.path()));
+        let usage = summaries.iter().find(|s| s.component == "usage");
+        assert!(usage.is_some());
+        Ok(())
+    }
+}

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -133,6 +133,45 @@ pub fn cycle_type(path: &Path, widget_name: &str) -> Result<String> {
     Ok(next.to_string())
 }
 
+/// 创建一个默认模板的静态 widget。
+/// 模板:enabled=true, type=static, row=1, col=0, content="new widget"。
+pub fn create_widget(path: &Path, widget_name: &str) -> Result<()> {
+    if widget_name.is_empty() {
+        bail!("widget 名字不能为空");
+    }
+    if !widget_name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+    {
+        bail!("widget 名字只能是字母/数字/下划线/短横");
+    }
+
+    let mut doc = load_document(path).unwrap_or_default();
+
+    let widgets = doc
+        .entry("widgets")
+        .or_insert(Item::Table(toml_edit::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("widgets 不是表"))?;
+
+    if widgets.contains_key(widget_name) {
+        bail!("widget '{widget_name}' 已存在,不能重复创建");
+    }
+
+    let mut table = toml_edit::Table::new();
+    table.insert("enabled", toml_value(true));
+    table.insert("type", toml_value("static"));
+    table.insert("row", toml_value(1_i64));
+    table.insert("col", toml_value(0_i64));
+    table.insert("nerd_icon", toml_value(""));
+    table.insert("emoji_icon", toml_value("📌"));
+    table.insert("text_icon", toml_value("[?]"));
+    table.insert("content", toml_value("new widget"));
+    widgets.insert(widget_name, Item::Table(table));
+
+    save_document(path, &doc)
+}
+
 /// 删除整个 widget 表。
 pub fn delete_widget(path: &Path, widget_name: &str) -> Result<()> {
     let mut doc = load_document(path)?;
@@ -275,6 +314,25 @@ text_icon = "[y]"
         assert_eq!(new_type, "api");
         let new_type = cycle_type(&path, "foo")?;
         assert_eq!(new_type, "static");
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_widget() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_sample(temp.path())?;
+        create_widget(&path, "freshy")?;
+        let files = scan_files(Some(temp.path()));
+        let usage = files.iter().find(|f| f.component == "usage");
+        let usage = match usage {
+            Some(u) => u,
+            None => return Ok(()),
+        };
+        assert!(usage.entries.iter().any(|e| e.name == "freshy"));
+        // 重复创建应报错
+        assert!(create_widget(&path, "freshy").is_err());
+        // 非法名字应报错
+        assert!(create_widget(&path, "bad name").is_err());
         Ok(())
     }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -12,7 +12,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use toml_edit::{value as toml_value, DocumentMut, Item};
 
 use claude_code_statusline_pro::config::ComponentMultilineConfig;
-use claude_code_statusline_pro::utils;
 
 /// 旧版本只读摘要(向后兼容,其他 v2 代码还在用)。
 pub struct WidgetSummary {
@@ -57,21 +56,22 @@ pub fn scan_summaries(project_base_dir: Option<&Path>) -> Vec<WidgetSummary> {
 
 /// 扫描并返回每个文件里的 widget 完整元信息。
 ///
-/// 在 user scope 下,`project_base_dir` 解析出的组件目录会与用户级目录
-/// 指向同一位置(`~/.claude/statusline-pro/components`),必须去重避免
-/// 同一个 widget 被扫两次。去重基于 canonicalize 后的绝对路径。
-pub fn scan_files(project_base_dir: Option<&Path>) -> Vec<WidgetFile> {
+/// 只扫描传入的 `base_dir/components`。以前会把 `~/.claude/statusline-pro
+/// /components` 无条件拼进来,在 project / custom scope 下同一个组件会
+/// 同时冒出用户层和项目层两份;选到用户层那条执行 toggle / delete,
+/// 写的是用户文件,但预览和运行时都优先读项目层,结果就是"改了没效果"
+/// 但用户文件已被悄悄动过。widget CRUD 必须只作用于当前正在编辑的这一层。
+///
+/// 调用方只需传入"正在编辑的那份 config 的目录"(一般就是
+/// `options.path.parent()`):user scope 传用户配置目录、project scope
+/// 传项目配置目录、custom scope 传 custom 文件所在目录,语义统一。
+///
+/// 仍保留基于 canonicalize 的去重,主要挡住调用者重复传同一路径的情况。
+pub fn scan_files(base_dir: Option<&Path>) -> Vec<WidgetFile> {
     let mut out = Vec::new();
     let mut seen: HashSet<PathBuf> = HashSet::new();
 
-    if let Some(home) = utils::home_dir() {
-        collect_from_dir(
-            &home.join(".claude/statusline-pro/components"),
-            &mut out,
-            &mut seen,
-        );
-    }
-    if let Some(base) = project_base_dir {
+    if let Some(base) = base_dir {
         collect_from_dir(&base.join("components"), &mut out, &mut seen);
     }
 
@@ -335,6 +335,47 @@ text_icon = "[y]"
         };
         assert!(foo.enabled);
         assert_eq!(foo.kind, "static");
+        Ok(())
+    }
+
+    /// 回归:scan_files 只能读传入 base_dir 下的 components,不能把
+    /// 用户配置目录或别的层级的 widget 混进来。之前 scan_files 会无条件
+    /// 附带 `~/.claude/statusline-pro/components`,在 project / custom
+    /// scope 下会把用户层 widget 和项目层 widget 混在一起,toggle/delete
+    /// 可能写到错误层。
+    #[test]
+    fn test_scan_files_is_scoped_to_base_dir() -> Result<()> {
+        // 故意构造两个独立目录,模拟"project 层"和"user 层";
+        // 只把 project 层传进 scan_files,就不能看到 user 层的条目。
+        let project_dir = tempfile::tempdir()?;
+        write_sample(project_dir.path())?;
+
+        let user_dir = tempfile::tempdir()?;
+        let user_components = user_dir.path().join("components");
+        fs::create_dir_all(&user_components)?;
+        fs::write(
+            user_components.join("user_only.toml"),
+            r#"
+[widgets.user_widget]
+enabled = true
+type = "static"
+row = 1
+col = 0
+nerd_icon = "u"
+emoji_icon = "u"
+text_icon = "[u]"
+content = "from user layer"
+"#,
+        )?;
+
+        let files = scan_files(Some(project_dir.path()));
+        // 项目层应该能看到
+        assert!(files.iter().any(|f| f.component == "usage"));
+        // 用户层的文件无论如何都不能混进来
+        assert!(
+            files.iter().all(|f| f.component != "user_only"),
+            "scan_files 不应越过 base_dir 去读其他层的 components"
+        );
         Ok(())
     }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -6,9 +6,11 @@
 
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
+use tempfile::NamedTempFile;
 use toml_edit::{value as toml_value, DocumentMut, InlineTable, Item, Value};
 
 use claude_code_statusline_pro::config::ComponentMultilineConfig;
@@ -243,9 +245,20 @@ fn load_document(path: &Path) -> Result<DocumentMut> {
 }
 
 fn save_document(path: &Path, doc: &DocumentMut) -> Result<()> {
-    let tmp = path.with_extension("toml.tmp");
-    fs::write(&tmp, doc.to_string()).with_context(|| format!("写 {} 失败", tmp.display()))?;
-    fs::rename(&tmp, path).with_context(|| format!("重命名失败: {}", path.display()))?;
+    // 和 tui::io::save 走同一套 write-temp + fsync + atomic-replace 路径:
+    // Windows 上旧实现用 `fs::rename` 在目标已存在时会失败,导致修改现有
+    // components/*.toml 文件的 toggle/delete/cycle/create 全部写不进去。
+    // NamedTempFile::persist 跨平台保证替换语义正确。
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("创建临时文件失败(目录 {})", parent.display()))?;
+    tmp.write_all(doc.to_string().as_bytes())
+        .with_context(|| format!("写 {} 失败", tmp.path().display()))?;
+    tmp.as_file_mut()
+        .sync_all()
+        .with_context(|| format!("flush 临时文件失败: {}", tmp.path().display()))?;
+    tmp.persist(path)
+        .map_err(|err| anyhow!("原子替换失败 {}: {}", path.display(), err.error))?;
     Ok(())
 }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
-use toml_edit::{value as toml_value, DocumentMut, Item};
+use toml_edit::{value as toml_value, DocumentMut, InlineTable, Item, Value};
 
 use claude_code_statusline_pro::config::ComponentMultilineConfig;
 
@@ -170,26 +170,48 @@ pub fn create_widget(path: &Path, widget_name: &str) -> Result<()> {
         DocumentMut::new()
     };
 
+    // 先决定新 widget 要以 inline 还是常规 [widgets.name] 表头写进去。
+    // 判定基于外层 `widgets` 现在的形态:如果用户用的是 inline
+    // `widgets = { foo = { ... } }`,新加的也用 inline 保留一致的风格;
+    // 如果是常规表 `[widgets.foo]` 或不存在(新文件),就用常规表头。
+    // 硬塞 Item::Table 进 inline 会破坏原文件的格式甚至失败。
+    let widgets_is_inline = matches!(doc.get("widgets"), Some(Item::Value(Value::InlineTable(_))));
+
     let widgets = doc
         .entry("widgets")
         .or_insert(Item::Table(toml_edit::Table::new()))
-        .as_table_mut()
+        .as_table_like_mut()
         .ok_or_else(|| anyhow!("widgets 不是表"))?;
 
     if widgets.contains_key(widget_name) {
         bail!("widget '{widget_name}' 已存在,不能重复创建");
     }
 
-    let mut table = toml_edit::Table::new();
-    table.insert("enabled", toml_value(true));
-    table.insert("type", toml_value("static"));
-    table.insert("row", toml_value(1_i64));
-    table.insert("col", toml_value(0_i64));
-    table.insert("nerd_icon", toml_value(""));
-    table.insert("emoji_icon", toml_value("📌"));
-    table.insert("text_icon", toml_value("[?]"));
-    table.insert("content", toml_value("new widget"));
-    widgets.insert(widget_name, Item::Table(table));
+    let new_entry = if widgets_is_inline {
+        // inline 分支:构造一张 InlineTable,字段顺序和常规表一致,便于阅读。
+        let mut inline = InlineTable::new();
+        inline.insert("enabled", Value::from(true));
+        inline.insert("type", Value::from("static"));
+        inline.insert("row", Value::from(1_i64));
+        inline.insert("col", Value::from(0_i64));
+        inline.insert("nerd_icon", Value::from(""));
+        inline.insert("emoji_icon", Value::from("📌"));
+        inline.insert("text_icon", Value::from("[?]"));
+        inline.insert("content", Value::from("new widget"));
+        Item::Value(Value::InlineTable(inline))
+    } else {
+        let mut table = toml_edit::Table::new();
+        table.insert("enabled", toml_value(true));
+        table.insert("type", toml_value("static"));
+        table.insert("row", toml_value(1_i64));
+        table.insert("col", toml_value(0_i64));
+        table.insert("nerd_icon", toml_value(""));
+        table.insert("emoji_icon", toml_value("📌"));
+        table.insert("text_icon", toml_value("[?]"));
+        table.insert("content", toml_value("new widget"));
+        Item::Table(table)
+    };
+    widgets.insert(widget_name, new_entry);
 
     save_document(path, &doc)
 }
@@ -197,9 +219,11 @@ pub fn create_widget(path: &Path, widget_name: &str) -> Result<()> {
 /// 删除整个 widget 表。
 pub fn delete_widget(path: &Path, widget_name: &str) -> Result<()> {
     let mut doc = load_document(path)?;
+    // 同样用 as_table_like_mut:inline `widgets = { ... }` 也要能删除子项,
+    // 不能因为外层是 inline 写法就拒绝。
     let widgets = doc
         .get_mut("widgets")
-        .and_then(|i| i.as_table_mut())
+        .and_then(|i| i.as_table_like_mut())
         .ok_or_else(|| anyhow!("{} 中没有 [widgets] 表", path.display()))?;
     if widgets.remove(widget_name).is_none() {
         bail!("widget '{widget_name}' 不存在于 {}", path.display());
@@ -245,15 +269,20 @@ fn widget_get_string(doc: &DocumentMut, widget: &str, key: &str) -> Option<Strin
 }
 
 fn widget_set(doc: &mut DocumentMut, widget: &str, key: &str, value: Item) -> Result<()> {
+    // 之前这里直接 as_table_mut(),对 `widgets = { foo = { enabled = true } }`
+    // 这种完全合法的 inline-table 写法就走不通:读的时候 as_table_like 是通的,
+    // 写的时候 as_table_mut 只认 Item::Table,inline 被当成"不是表"拒绝,
+    // 整份用户配置就变成只读的了。切到 as_table_like_mut + TableLike 接口,
+    // 同时支持 Item::Table 和 Item::Value(InlineTable)。
     let widgets = doc
         .entry("widgets")
         .or_insert(Item::Table(toml_edit::Table::new()))
-        .as_table_mut()
+        .as_table_like_mut()
         .ok_or_else(|| anyhow!("widgets 不是表"))?;
     let widget_table = widgets
         .entry(widget)
         .or_insert(Item::Table(toml_edit::Table::new()))
-        .as_table_mut()
+        .as_table_like_mut()
         .ok_or_else(|| anyhow!("widgets.{widget} 不是表"))?;
     widget_table.insert(key, value);
     Ok(())
@@ -453,6 +482,94 @@ content = "from user layer"
             None => return Ok(()),
         };
         assert!(usage.entries.iter().all(|e| e.name != "bar"));
+        Ok(())
+    }
+
+    /// 写一份"外层 + 每个 widget 都用 inline 写法"的样本,用来校验 CRUD
+    /// 对 `widgets = { foo = { ... } }` 这种合法但少见的 TOML 形态同样生效。
+    fn write_inline_sample(dir: &Path) -> Result<PathBuf> {
+        let comp_dir = dir.join("components");
+        fs::create_dir_all(&comp_dir)?;
+        let path = comp_dir.join("inline.toml");
+        fs::write(
+            &path,
+            r#"widgets = { foo = { enabled = true, type = "static", row = 1, col = 0, nerd_icon = "x", emoji_icon = "x", text_icon = "[x]", content = "hi" }, bar = { enabled = false, type = "api", row = 1, col = 1, nerd_icon = "y", emoji_icon = "y", text_icon = "[y]" } }
+"#,
+        )?;
+        Ok(path)
+    }
+
+    /// 回归 Codex round 9 / P2:toggle_enabled 必须支持 inline widgets。
+    /// 以前 widget_set 用 as_table_mut,外层 inline `widgets = { ... }` 或
+    /// 内层 inline `foo = { ... }` 都会走不通,报 "不是表"。
+    #[test]
+    fn test_toggle_enabled_on_inline_widget() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_inline_sample(temp.path())?;
+        // foo 默认 enabled = true → 翻到 false
+        let new_value = toggle_enabled(&path, "foo")?;
+        assert!(!new_value);
+        // 再翻一次应该回到 true
+        let new_value = toggle_enabled(&path, "foo")?;
+        assert!(new_value);
+        Ok(())
+    }
+
+    /// inline widgets 里切换 type 也得可行。
+    #[test]
+    fn test_cycle_type_on_inline_widget() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_inline_sample(temp.path())?;
+        let new_type = cycle_type(&path, "foo")?;
+        assert_eq!(new_type, "api");
+        Ok(())
+    }
+
+    /// 外层 inline 的情况下,delete_widget 依然能移除子项。
+    #[test]
+    fn test_delete_widget_from_inline_root() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_inline_sample(temp.path())?;
+        delete_widget(&path, "bar")?;
+        // bar 应被移除,foo 依然存在
+        let files = scan_files(Some(temp.path()));
+        let inline = files
+            .iter()
+            .find(|f| f.component == "inline")
+            .expect("inline component should still be readable");
+        assert!(inline.entries.iter().any(|e| e.name == "foo"));
+        assert!(inline.entries.iter().all(|e| e.name != "bar"));
+        Ok(())
+    }
+
+    /// 外层 inline 的情况下,create_widget 应以 inline 子表形式写入,
+    /// 保留用户选择的风格而不是硬加一个 [widgets.name] 表头把文件弄混。
+    #[test]
+    fn test_create_widget_on_inline_root_preserves_inline_style() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_inline_sample(temp.path())?;
+        create_widget(&path, "baz")?;
+
+        // scan_files 必须能读到新加的 baz
+        let files = scan_files(Some(temp.path()));
+        let inline = files
+            .iter()
+            .find(|f| f.component == "inline")
+            .expect("inline component should survive create");
+        assert!(inline.entries.iter().any(|e| e.name == "baz"));
+
+        // 文本层面:外层仍然是 inline 写法(第一行依然 `widgets = {`),
+        // 而不是被升级成了 `[widgets.baz]` 表头。
+        let text = fs::read_to_string(&path)?;
+        let first_line = text.lines().next().unwrap_or("");
+        assert!(
+            first_line.starts_with("widgets = {"),
+            "expected inline widgets to stay inline, got: {first_line:?}"
+        );
+        assert!(
+            !text.contains("[widgets.baz]"),
+            "create_widget 不应在 inline 根下插入表头语法"
+        );
         Ok(())
     }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -4,6 +4,7 @@
 //! widget 元信息,并提供三个 CRUD 操作(toggle_enabled / cycle_type / delete)。
 //! 所有写入都走 `toml_edit::DocumentMut`,保留注释与顺序。
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -55,22 +56,36 @@ pub fn scan_summaries(project_base_dir: Option<&Path>) -> Vec<WidgetSummary> {
 // ---- v3 完整扫描 ----
 
 /// 扫描并返回每个文件里的 widget 完整元信息。
+///
+/// 在 user scope 下,`project_base_dir` 解析出的组件目录会与用户级目录
+/// 指向同一位置(`~/.claude/statusline-pro/components`),必须去重避免
+/// 同一个 widget 被扫两次。去重基于 canonicalize 后的绝对路径。
 pub fn scan_files(project_base_dir: Option<&Path>) -> Vec<WidgetFile> {
     let mut out = Vec::new();
+    let mut seen: HashSet<PathBuf> = HashSet::new();
 
     if let Some(home) = utils::home_dir() {
-        collect_from_dir(&home.join(".claude/statusline-pro/components"), &mut out);
+        collect_from_dir(
+            &home.join(".claude/statusline-pro/components"),
+            &mut out,
+            &mut seen,
+        );
     }
     if let Some(base) = project_base_dir {
-        collect_from_dir(&base.join("components"), &mut out);
+        collect_from_dir(&base.join("components"), &mut out, &mut seen);
     }
 
     out.sort_by(|a, b| a.component.cmp(&b.component));
     out
 }
 
-fn collect_from_dir(dir: &Path, out: &mut Vec<WidgetFile>) {
+fn collect_from_dir(dir: &Path, out: &mut Vec<WidgetFile>, seen: &mut HashSet<PathBuf>) {
     if !dir.exists() {
+        return;
+    }
+    // canonicalize 在目录存在时一定成功,fallback 只是保守兜底
+    let canonical = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    if !seen.insert(canonical) {
         return;
     }
     let Ok(entries) = fs::read_dir(dir) else {
@@ -270,6 +285,28 @@ text_icon = "[y]"
 "#,
         )?;
         Ok(path)
+    }
+
+    /// 模拟 user scope:project_base_dir 就是组件目录的父目录,
+    /// 和 utils::home_dir() 得到的路径重合时不应该扫出重复条目。
+    #[test]
+    fn test_scan_files_dedups_same_dir() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = write_sample(temp.path())?;
+        // 用相同路径调两次 collect_from_dir
+        let mut out = Vec::new();
+        let mut seen = HashSet::new();
+        let dir = path
+            .parent()
+            .ok_or_else(|| anyhow!("sample path missing parent"))?;
+        collect_from_dir(dir, &mut out, &mut seen);
+        collect_from_dir(dir, &mut out, &mut seen);
+        assert_eq!(
+            out.iter().filter(|f| f.component == "usage").count(),
+            1,
+            "same dir scanned twice should not duplicate"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -161,7 +161,14 @@ pub fn create_widget(path: &Path, widget_name: &str) -> Result<()> {
         bail!("widget 名字只能是字母/数字/下划线/短横");
     }
 
-    let mut doc = load_document(path).unwrap_or_default();
+    // 文件存在时必须严格解析,parse 失败绝不能用空 DocumentMut 覆盖
+    // (否则新建 widget 的同时会把原文件的所有注释和 widgets 一起抹掉)。
+    // 文件不存在才是合法的"从空开始"场景。
+    let mut doc = if path.exists() {
+        load_document(path)?
+    } else {
+        DocumentMut::new()
+    };
 
     let widgets = doc
         .entry("widgets")
@@ -370,6 +377,26 @@ text_icon = "[y]"
         assert!(create_widget(&path, "freshy").is_err());
         // 非法名字应报错
         assert!(create_widget(&path, "bad name").is_err());
+        Ok(())
+    }
+
+    /// 回归:create_widget 在目标文件 TOML 解析失败时必须报错,
+    /// 不能静默用空 DocumentMut 覆盖掉用户的原文件。
+    #[test]
+    fn test_create_widget_refuses_to_clobber_malformed_file() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let comp_dir = temp.path().join("components");
+        fs::create_dir_all(&comp_dir)?;
+        let path = comp_dir.join("broken.toml");
+        let original = "this is not valid TOML = = [\n";
+        fs::write(&path, original)?;
+
+        let err = create_widget(&path, "anything").expect_err("should refuse to write");
+        let _ = err;
+
+        // 确认原文件内容没有被改写
+        let after = fs::read_to_string(&path)?;
+        assert_eq!(after, original, "malformed file must not be overwritten");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

New subcommand **`ccsp config edit`** opens a ratatui-based TUI editor for
`~/.claude/statusline-pro/config.toml` (and project-level configs), with a
live **colored** statusline preview driven by the existing mock scenarios.

Zero changes to existing commands / output; adds a dependency on
`ratatui 0.29` + `ansi-to-tui 7`.

## What's in the editor

- **12 tabs** — basic / style / terminal / 6 components / theme / multiline / widgets
- **6 field kinds** — Text, Bool, Enum, Color, Int, Float (range-validated)
- **Live preview** with full ANSI color via `ansi-to-tui`
- **Text editor** with cursor: ← → Home End Ctrl+A/E Delete, UTF-8 safe
- **Color palette swatches** rendered in the help pane; Space cycles, Enter lets you type hex
- **Cross-tab search** (/) matches section / label / path
- **Merge report overlay** (F2) — visualizes default→user→project layer chain with added/overridden keys
- **Scope switch** (Ctrl+T) swaps user ↔ project in place, with dirty-check refusal
- **Widgets CRUD** — `n` creates from a default static template, Space toggles enabled, `t` cycles type, `d`/Delete removes
- **TTY guard** — subcommand bails cleanly when stdin/stdout isn't a TTY, so Claude Code calling `ccsp` as its statusline command won't accidentally drop into the editor

All writes go through `toml_edit::DocumentMut`, **preserving comments, ordering, and formatting**. Saves are atomic (`tmp` + `rename`) and gated by a `Config` reserialization check — malformed edits never hit disk.

## Module layout

```
src/tui/
├── mod.rs       — entry, TTY check, display helpers
├── app.rs       — state machine (section/field/mode/search/widgets/merge)
├── event.rs     — keybinding dispatcher (normal / edit / search / widgets / overlays)
├── view.rs      — ratatui rendering (header / tabs / body / preview / footer / overlays)
├── sections.rs  — static field metadata across 11 field tabs + 1 widgets marker
├── io.rs        — toml_edit get/set helpers with decor preservation
├── preview.rs   — ANSI → ratatui Line conversion
└── widgets.rs   — component file scan + widget CRUD
```

~3300 lines across these 8 files. Commit history splits the work:

1. `chore: add ratatui + ansi-to-tui deps` — just Cargo.{toml,lock}
2. `feat(tui): add interactive config editor` — core TUI + subcommand wiring
3. `feat(tui): editor polish — cursor, color swatch, widget create` — EditBuffer w/ cursor, color palette preview, widget new dialog

## Tests

**26 TUI unit tests** pass, covering:
- TOML round-trips + comment preservation
- ANSI parsing via ansi-to-tui
- Widget scan / toggle / cycle / delete / create
- EditBuffer cursor semantics with UTF-8 (α, β, 中, 英, 日)
- Color name + hex parser

All other existing tests still pass (19 binary + 2 storage).

## Known pre-existing test failure

`components::model` has 9 pre-existing test failures unrelated to this PR — they come from a `CLAUDE_CODE_EFFORT_LEVEL` env var leaking into the test process (the effort-symbol `◐` gets appended to model names). The failures reproduce on a clean main branch. Worth a separate fix with `serial_test` + env cleanup.

## Test plan

- [ ] `cargo build --release` — release binary builds clean
- [ ] `cargo clippy --all-targets -- -D warnings` — strict clippy green
- [ ] `cargo test --bin claude-code-statusline-pro tui` — 26 TUI tests pass
- [ ] Run `./target/release/claude-code-statusline-pro config edit --help` — subcommand wired
- [ ] Run `./target/release/claude-code-statusline-pro config edit < /dev/null` — TTY guard refuses cleanly
- [ ] In a real terminal: `ccsp config edit`, walk through all tabs, edit a color to hex, search for a field via `/`, open merge report with F2, switch scope with Ctrl+T, create/delete a widget