### PR TITLE
test(config): serialize HOME-mutating loader test

### DIFF
--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -720,7 +720,13 @@ mod tests {
     use std::env;
     use tempfile::tempdir;
 
+    // 必须 #[serial]:这个测试 env::set_var("HOME", ...) 但不恢复,
+    // 会和 utils::tests::falls_back_to_dirs_home_dir 以及 utils::effort
+    // 里的 HOME-mutating 测试发生竞态。serial_test 已经在用它们给 HOME
+    // 敏感测试做全局互斥,这里必须加入同一把锁,不然在 1.85 这种特定的
+    // 调度下 MSRV CI 会偶发失败(main 分支上就能复现,这是 pre-existing bug)。
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_load_default_config() -> Result<()> {
         // Create a temporary directory for the test
         let temp_dir = tempdir()?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -50,7 +50,13 @@ mod tests {
     use std::ffi::OsString;
     use tempfile::tempdir;
 
+    // 也必须 #[serial]:此测试 set_var(HOME, tempdir) 再恢复,和 falls_back
+    // 那条(remove_var + 读 dirs::home_dir())互为镜像 —— falls_back 读取时
+    // 需要 HOME 真的被移除,如果这个测试并发地把 HOME 设回 tempdir,断言
+    // 就会看到 `detected == dirs::home_dir()` 两边不一致。必须用同一把
+    // serial_test 锁串起来。
     #[test]
+    #[serial_test::serial]
     fn respects_home_env_when_present() -> Result<()> {
         let dir = tempdir()?;
         let original = env::var_os("HOME");


### PR DESCRIPTION
## Summary

- `config::loader::tests::test_load_default_config` calls `env::set_var("HOME", ...)` but was not tagged `#[serial_test::serial]`.
- In the lib test binary it runs concurrently with the other HOME-sensitive tests (`utils::tests::falls_back_to_dirs_home_dir`, `utils::effort::tests::*`) which **are** all `#[serial]`. Under certain thread interleavings the `falls_back` test removes HOME, this test sets HOME to its tempdir mid-assertion, and the assertion `detected == dirs::home_dir()` ends up comparing two different reads of HOME → it fires the `left != right` panic.
- Joining the existing serial group (one attribute) removes the race deterministically. No behavior change.

## Why this matters

Surfaced as a flaky MSRV (1.85) CI failure on PR #53: same HEAD passed on rerun because the scheduler happened to not interleave the two tests. MSRV currently only runs when `lint-test` passes, so earlier PRs often never got to MSRV at all and the flake stayed invisible.

## Test plan

- [x] `cargo test --lib config::loader::tests::test_load_default_config` — passes
- [ ] CI Lint & Test on all 3 OS
- [ ] MSRV 1.85 CI passes cleanly without rerun
