### PR TITLE
chore(release): add candidate gate + rewire npm publishing (stage 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,20 @@
 #   ccsp, claude-code-statusline-pro, @wangnov/ccsp-{linux,macos,windows}-{x64,arm64}
 name: Build
 
+# Codex review flagged two problems with the previous `on: release: published`
+# trigger:
+#   P1 - GitHub does not dispatch new workflow runs for events created by the
+#        default GITHUB_TOKEN (anti-recursion). release.yml uses GITHUB_TOKEN
+#        to publish the GitHub Release, so a `release: published` listener
+#        here would never actually fire. `workflow_run` is exempt from that
+#        restriction.
+#   P2 - For workflow_dispatch re-runs we must check out the exact tag, not
+#        the default branch, or the npm wrappers on main get bundled with
+#        older binaries and republished under the old version.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -26,24 +37,31 @@ jobs:
   assemble-npm:
     name: assemble npm package
     runs-on: ubuntu-latest
+    # Only fire when the upstream Release workflow finished successfully on a
+    # version tag, or on an explicit manual dispatch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     environment:
       name: npm-release
 
     steps:
-      - uses: actions/checkout@v6
-
       - name: Determine release tag
         id: tag
         env:
           GH_EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          # On workflow_run from a tag push, head_branch is the tag name
+          # (e.g. "v3.1.5"), not the source branch.
+          WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [[ "$GH_EVENT_NAME" == "workflow_dispatch" ]]; then
             TAG="$INPUT_TAG"
           else
-            TAG="$RELEASE_TAG"
+            TAG="$WORKFLOW_RUN_BRANCH"
           fi
           if [[ -z "$TAG" ]]; then
             echo "::error::could not determine release tag"
@@ -53,6 +71,13 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Using tag=${TAG}, version=${VERSION}"
+
+      # Check out the exact commit the tag points at so the npm wrappers
+      # packaged here match the binaries in the GitHub Release (addresses
+      # Codex P2 for workflow_dispatch reruns after main has advanced).
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Download cargo-dist release assets
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,135 +1,167 @@
+# npm publishing pipeline. Binaries are built by the cargo-dist generated
+# release.yml on tag-push; this workflow fires *after* that, downloads the
+# platform archives from the GitHub Release, extracts the binaries into the
+# npm platform packages, and publishes them via trusted publishing.
+#
+# Keeping this file's name (build.yml) and the job name (assemble-npm)
+# unchanged preserves the existing npm trusted-publisher bindings for:
+#   ccsp, claude-code-statusline-pro, @wangnov/ccsp-{linux,macos,windows}-{x64,arm64}
 name: Build
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v3.1.5) to rebuild npm packages for."
+        required: true
+        type: string
 
 permissions:
   contents: read
-  actions: write
-  id-token: write  # 添加此权限以启用 OIDC
+  id-token: write # npm trusted publishing OIDC
 
 jobs:
-  build:
-    name: build ${{ matrix.platform }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            platform: linux-x64
-            binary: claude-code-statusline-pro
-            artifact: linux-x64
-            use_cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            platform: linux-arm64
-            binary: claude-code-statusline-pro
-            artifact: linux-arm64
-            use_cross: true
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            platform: macos-x64
-            binary: claude-code-statusline-pro
-            artifact: macos-x64
-            use_cross: false
-          - os: macos-15
-            target: aarch64-apple-darwin
-            platform: macos-arm64
-            binary: claude-code-statusline-pro
-            artifact: macos-arm64
-            use_cross: false
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: windows-x64
-            binary: claude-code-statusline-pro.exe
-            artifact: windows-x64
-            use_cross: false
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
-            platform: windows-arm64
-            binary: claude-code-statusline-pro.exe
-            artifact: windows-arm64
-            use_cross: false
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install cross
-        if: matrix.use_cross
-        run: cargo install cross --version 0.2.5 --locked
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Build ${{ matrix.target }}
-        shell: bash
-        run: |
-          if [[ "${{ matrix.use_cross }}" == "true" ]]; then
-            cross build --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
-
-      - name: Collect artifact
-        run: |
-          mkdir -p artifacts
-          cp target/${{ matrix.target }}/release/${{ matrix.binary }} artifacts/
-        shell: bash
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.artifact }}
-          path: artifacts/${{ matrix.binary }}
-
   assemble-npm:
     name: assemble npm package
     runs-on: ubuntu-latest
-    needs: build
     environment:
       name: npm-release
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v8
-        with:
-          path: dist/artifacts
+      - name: Determine release tag
+        id: tag
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$GH_EVENT_NAME" == "workflow_dispatch" ]]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="$RELEASE_TAG"
+          fi
+          if [[ -z "$TAG" ]]; then
+            echo "::error::could not determine release tag"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using tag=${TAG}, version=${VERSION}"
+
+      - name: Download cargo-dist release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --dir dist/release \
+            --pattern 'claude-code-statusline-pro-*.tar.xz' \
+            --pattern 'claude-code-statusline-pro-*.zip'
+          ls -la dist/release
+
+      - name: Extract platform binaries
+        run: |
+          set -euo pipefail
+          mkdir -p dist/bin
+          cd dist/release
+
+          # Map npm platform label -> cargo-dist target triple
+          declare -A TARGETS=(
+            [linux-x64]=x86_64-unknown-linux-musl
+            [linux-arm64]=aarch64-unknown-linux-musl
+            [macos-x64]=x86_64-apple-darwin
+            [macos-arm64]=aarch64-apple-darwin
+            [windows-x64]=x86_64-pc-windows-msvc
+            [windows-arm64]=aarch64-pc-windows-msvc
+          )
+
+          for platform in "${!TARGETS[@]}"; do
+            target="${TARGETS[$platform]}"
+            case "$platform" in
+              windows-*)
+                archive="claude-code-statusline-pro-${target}.zip"
+                bin="claude-code-statusline-pro.exe"
+                dest="../bin/${platform}.exe"
+                ;;
+              *)
+                archive="claude-code-statusline-pro-${target}.tar.xz"
+                bin="claude-code-statusline-pro"
+                dest="../bin/${platform}"
+                ;;
+            esac
+
+            if [[ ! -f "$archive" ]]; then
+              echo "::error::missing archive for ${platform}: ${archive}"
+              exit 1
+            fi
+
+            tmp="$(mktemp -d)"
+            if [[ "$archive" == *.zip ]]; then
+              unzip -q "$archive" -d "$tmp"
+            else
+              tar -xf "$archive" -C "$tmp"
+            fi
+            cp "${tmp}/claude-code-statusline-pro-${target}/${bin}" "$dest"
+            rm -rf "$tmp"
+          done
+
+          ls -la ../bin
+
+      - name: Patch package.json versions to match release tag
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+          const version = process.env.VERSION;
+          const files = [
+            'npm/ccsp/package.json',
+            'npm/claude-code-statusline-pro/package.json',
+          ];
+          const platformsDir = 'npm/platforms';
+          for (const d of fs.readdirSync(platformsDir)) {
+            const p = path.join(platformsDir, d, 'package.json');
+            if (fs.existsSync(p)) files.push(p);
+          }
+          for (const f of files) {
+            const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));
+            pkg.version = version;
+            if (pkg.optionalDependencies) {
+              for (const k of Object.keys(pkg.optionalDependencies)) {
+                pkg.optionalDependencies[k] = version;
+              }
+            }
+            fs.writeFileSync(f, JSON.stringify(pkg, null, 2) + '\n');
+            console.log(`patched ${f} -> ${version}`);
+          }
+          NODE
 
       - name: Arrange binaries for npm packages
         run: |
           set -euo pipefail
-
-          declare -a PLATFORMS=(
-            "macos-arm64:claude-code-statusline-pro:ccsp"
-            "macos-x64:claude-code-statusline-pro:ccsp"
-            "linux-x64:claude-code-statusline-pro:ccsp"
-            "linux-arm64:claude-code-statusline-pro:ccsp"
-            "windows-x64:claude-code-statusline-pro.exe:ccsp.exe"
-            "windows-arm64:claude-code-statusline-pro.exe:ccsp.exe"
-          )
-
-          for entry in "${PLATFORMS[@]}"; do
-            IFS=":" read -r platform sourceBinary destBinary <<<"$entry"
+          for platform in macos-arm64 macos-x64 linux-x64 linux-arm64; do
             pkg_dir="npm/platforms/ccsp-${platform}/bin"
-            mkdir -p "${pkg_dir}"
-
-            artifact_path="dist/artifacts/${platform}/${sourceBinary}"
-            if [ -f "${artifact_path}" ]; then
-              cp "${artifact_path}" "${pkg_dir}/${destBinary}"
-              if [[ "${destBinary}" != *.exe ]]; then
-                chmod +x "${pkg_dir}/${destBinary}"
-              fi
-              rm -f "${pkg_dir}/.gitkeep"
-            else
-              echo "No artifact found for ${platform}, leaving placeholder."
-            fi
+            mkdir -p "$pkg_dir"
+            cp "dist/bin/${platform}" "${pkg_dir}/ccsp"
+            chmod +x "${pkg_dir}/ccsp"
+            rm -f "${pkg_dir}/.gitkeep"
+          done
+          for platform in windows-x64 windows-arm64; do
+            pkg_dir="npm/platforms/ccsp-${platform}/bin"
+            mkdir -p "$pkg_dir"
+            cp "dist/bin/${platform}.exe" "${pkg_dir}/ccsp.exe"
+            rm -f "${pkg_dir}/.gitkeep"
           done
 
       - name: Setup Node
@@ -158,7 +190,6 @@ jobs:
       - name: Pack main package (ccsp)
         run: |
           set -euo pipefail
-          # Copy README for npm display
           cp README.md npm/ccsp/
           rm -f npm/ccsp/*.tgz
           (cd npm/ccsp && npm pack)
@@ -166,17 +197,9 @@ jobs:
       - name: Pack legacy package (claude-code-statusline-pro)
         run: |
           set -euo pipefail
-          # Copy README for npm display
           cp README.md npm/claude-code-statusline-pro/
           rm -f npm/claude-code-statusline-pro/*.tgz
           (cd npm/claude-code-statusline-pro && npm pack)
-
-      - name: Read release version
-        id: release-version
-        run: |
-          set -euo pipefail
-          VERSION=$(node -p "require('./npm/ccsp/package.json').version")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Smoke test assembled packages (linux-x64)
         run: |
@@ -196,7 +219,7 @@ jobs:
 
       - name: Ensure npm versions are unpublished
         env:
-          VERSION: ${{ steps.release-version.outputs.version }}
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
           packages=(

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,124 @@
+# Release candidate gate for the cargo-release + cargo-dist flow.
+#
+# Purpose: *before* running `cargo release publish/tag/push` locally, the
+# maintainer manually dispatches this workflow to verify that the same build
+# that Release.yml will run on tag-push actually succeeds on every target.
+# Failing here means the release commit is reverted/amended; crates.io is
+# untouched.
+#
+# This workflow intentionally duplicates plan/build-local-artifacts from the
+# auto-generated release.yml so the dist planner, runner mapping, and
+# packaging logic are identical. It does NOT create a GitHub Release,
+# publish to any registry, or push the Homebrew formula.
+name: Release candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref (branch/tag/sha) to build from. Leave empty for the default branch."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-22.04
+    outputs:
+      val: ${{ steps.plan.outputs.manifest }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+          submodules: recursive
+      - name: Install dist
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+      - id: plan
+        run: |
+          dist plan --output-format=json > plan-dist-manifest.json
+          echo "dist plan succeeded"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c . plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: Upload plan manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: plan-dist-manifest
+          path: plan-dist-manifest.json
+
+  build-and-smoke:
+    name: build+smoke (${{ join(matrix.targets, ', ') }})
+    needs: plan
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container && matrix.container.image || null }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: enable windows longpaths
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+          submodules: recursive
+      - name: Install Rust non-interactively if not already installed
+        if: ${{ matrix.container }}
+        run: |
+          if ! command -v cargo > /dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          fi
+      - name: Install dist
+        run: ${{ matrix.install_dist.run }}
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
+      - name: Build artifacts (dist build)
+        run: |
+          dist build --print=linkage --output-format=json ${{ matrix.dist_args }}
+          echo "dist build succeeded"
+      - name: Smoke test release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="${{ matrix.targets[0] }}"
+          archive_dir="target/distrib"
+          tmp="$(mktemp -d)"
+
+          case "$target" in
+            *-windows-*)
+              archive="${archive_dir}/claude-code-statusline-pro-${target}.zip"
+              bin_name="claude-code-statusline-pro.exe"
+              unzip -q "$archive" -d "$tmp"
+              ;;
+            *)
+              archive="${archive_dir}/claude-code-statusline-pro-${target}.tar.xz"
+              bin_name="claude-code-statusline-pro"
+              tar -xf "$archive" -C "$tmp"
+              ;;
+          esac
+
+          bin="${tmp}/claude-code-statusline-pro-${target}/${bin_name}"
+          if [ ! -x "$bin" ] && [ ! -f "$bin" ]; then
+            echo "::error::binary not found at $bin"
+            ls -la "$tmp" || true
+            ls -la "${tmp}/claude-code-statusline-pro-${target}" || true
+            exit 1
+          fi
+
+          echo "--- $bin --version ---"
+          "$bin" --version
+
+          echo "--- $bin --help (head) ---"
+          "$bin" --help | head -20
+
+          echo "OK: smoke test passed for $target"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,24 +27,74 @@ make ci
 | `make ci` | 完整 CI 流程（推荐提交前执行） |
 | `make quick` | 快速检查（跳过自动修复） |
 | `make test` | 仅运行测试 |
-| `make bump V=x.x.x` | 更新版本号 |
+
+> `make bump` 已废弃，版本号由 `cargo release` 管理，见下文。
 
 ## 发布流程
 
+本项目采用 `cargo-release` + `cargo-dist` 两阶段发布流程。**crates.io 由 maintainer 本地推送，CI 只负责二进制构建与分发。**
+
+### 前置条件
+
+- 本地已登录 crates.io（`cargo login`），且当前账号对 `claude-code-statusline-pro` 有发布权限
+- 仓库已配置 `HOMEBREW_TAP_TOKEN` secret（推 Homebrew formula 到 `Wangnov/homebrew-tap`）
+
+### 阶段 1：准备候选版本
+
 ```bash
-# 1. 运行完整检查
+# 1. 保证主分支干净
 make ci
+git checkout main && git pull --ff-only
 
-# 2. 更新版本号
-make bump V=3.0.4
+# 2. 生成版本号 bump 的 release commit（不 publish、不打 tag、不 push）
+cargo release <patch|minor|major> --execute --no-publish --no-tag --no-push --no-confirm
 
-# 3. 提交并打 tag
-git add -A && git commit -m "chore: 更新版本号至 3.0.4"
-git tag v3.0.4
+# 3. 推送 release commit 到 main
+git push origin main
 
-# 4. 推送（触发 CI 构建和 npm 发布）
-git push origin main --tags
+# 4. 在 GitHub Actions 手动触发 "Release candidate" workflow
+#    使用 release commit 对应的 ref（默认 main 即可）
+#    该 workflow 会用 cargo-dist 构建 6 个平台的 archive 并跑 smoke test
 ```
+
+### 阶段 2：执行正式发布（候选全绿后）
+
+```bash
+# 5. 依次推 crates.io → 打 tag → 推 tag
+cargo release publish --execute --no-confirm
+cargo release tag --execute --no-confirm
+cargo release push --execute --no-confirm
+```
+
+tag 推送后 CI 自动接管：
+
+1. `release.yml`（cargo-dist 生成）→ 6 平台构建 + GitHub Release + Homebrew formula
+2. GitHub Release published 事件触发 `build.yml` → 下载 Release 资产 → 组装 npm 包 → 发布（trusted publishing）
+
+### 发布后验证
+
+```bash
+gh release view v<X.Y.Z>                          # GitHub Release 资产齐全？
+cargo search claude-code-statusline-pro --limit 1 # crates.io 版本正确？
+npm view ccsp version                             # npm 根包版本正确？
+npm view @wangnov/ccsp-linux-x64 version          # 平台包抽检
+```
+
+### 失败状态清理
+
+若候选全绿、crates.io 推送成功，但 tag 触发的 `release.yml` 失败：
+
+```bash
+# 删 tag（本地 + 远端），修完 release.yml 的问题后重新打 tag
+git tag -d v<X.Y.Z>
+git push origin :v<X.Y.Z>
+# 修复 → 在同一 release commit 上
+cargo release tag --execute --no-confirm
+cargo release push --execute --no-confirm
+# crates.io 保持原样；cargo release publish 会识别已发布状态并跳过
+```
+
+若需要**作废某个已推送的 crates.io 版本**（通常只在代码 bug 时）：`cargo yank --version <X.Y.Z>`，然后发布下一个 patch 版本。
 
 ## 项目结构
 

--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,32 @@ quick: fmt clippy check test
 clean:
 	cargo clean
 
-# 版本更新 (用法: make bump V=3.0.4)
+# 版本更新
+#
+# 已废弃：请使用 cargo-release + cargo-dist 的两阶段发布流程。
+#
+# npm 平台包的 version 字段不再需要手动维护——build.yml 会在发布时从
+# GitHub Release 的 tag 自动写回 package.json。只有 Cargo.toml 的
+# version 字段由 cargo-release 管理。
+#
+# 详见 CLAUDE.md「发布流程」章节。
 bump:
-ifndef V
-	$(error 请指定版本号，例如: make bump V=3.0.4)
-endif
-	sed -i '' 's/^version = "[^"]*"/version = "$(V)"/' Cargo.toml
-	find npm -name "package.json" -exec sed -i '' 's/"version": "[^"]*"/"version": "$(V)"/g' {} \;
-	cargo generate-lockfile
-	@echo "✅ Version bumped to $(V)"
+	@echo "⚠️  'make bump' 已废弃。"
+	@echo ""
+	@echo "请改用 cargo-release + cargo-dist 的两阶段发布流程："
+	@echo ""
+	@echo "  # 阶段 1：本地改版本号 + push + 手动触发候选 workflow"
+	@echo "  cargo release <patch|minor|major> --execute --no-publish --no-tag --no-push --no-confirm"
+	@echo "  git push origin main"
+	@echo "  # 然后在 GitHub Actions 页面手动触发 'Release candidate' workflow"
+	@echo ""
+	@echo "  # 阶段 2：候选全绿后，本地依次推 crates.io → 打 tag → 推 tag"
+	@echo "  cargo release publish --execute --no-confirm"
+	@echo "  cargo release tag --execute --no-confirm"
+	@echo "  cargo release push --execute --no-confirm"
+	@echo ""
+	@echo "详见 CLAUDE.md。"
+	@exit 1
 
 # 帮助信息
 help:
@@ -68,4 +85,5 @@ help:
 	@echo "  make test    - 运行测试"
 	@echo "  make build   - Release 构建"
 	@echo "  make clean   - 清理构建产物"
-	@echo "  make bump V=x.x.x - 更新版本号"
+	@echo ""
+	@echo "发布流程: 使用 cargo-release + cargo-dist (详见 CLAUDE.md)"


### PR DESCRIPTION
## Summary

Stage 2 of the `cargo-release` + `cargo-dist` pipeline. Stage 1 (#56) wired up the version-bump + binary-distribution side; this PR adds the **pre-publish CI gate** and **rewires npm** so cargo-dist owns binary creation end-to-end.

**Merging this PR does not publish anything.** Releases still only fire when a maintainer pushes a tag.

## What changes

### `.github/workflows/release-candidate.yml` (new)

Manually dispatched **before** `cargo release publish` runs locally. It duplicates `release.yml`'s `plan` and `build-local-artifacts` jobs — same cargo-dist matrix, same runner mapping, same `dist build` arguments — but **does not create a Release, publish to crates.io/npm, or push the Homebrew formula**.

Each matrix job additionally extracts its freshly built archive and runs the binary with `--version` and `--help` as a smoke test. If any of the six targets fails to build or run, the candidate is rejected and the maintainer fixes the release commit **before** anything hits crates.io.

### `.github/workflows/build.yml` (rewritten)

| | Before | After |
|---|---|---|
| Trigger | `on: push: tags: 'v*'` | `on: release: published` |
| Binary source | 6-target build matrix inside this workflow | `gh release download` from the cargo-dist Release |
| Version source | `package.json` committed in git | patched from the release tag at runtime |
| File name / job name / env | `build.yml` / `assemble-npm` / `npm-release` | **unchanged** — npm trusted-publishing bindings keep validating |

A `workflow_dispatch` with a `tag` input is retained, so a failed npm publish can be replayed against an existing Release without burning a version.

### `Makefile`

`make bump` now prints the new two-phase commands and exits 1. The `help` entry points at `CLAUDE.md`.

### `CLAUDE.md`

Release section fully rewritten: prerequisites → stage 1 (`cargo release --no-publish --no-tag --no-push` → `git push` → manual candidate) → stage 2 (`cargo release publish/tag/push`) → post-release verification → failure cleanup (`git tag -d` + re-tag on the same release commit).

## End-to-end flow after this PR merges

```
maintainer (local):
  cargo release patch --execute --no-publish --no-tag --no-push --no-confirm
  git push origin main
                           │
                           ▼
GitHub Actions (manual):
  release-candidate.yml  ── cargo-dist build × 6 targets + smoke test
                           │  (if red: fix release commit, retry)
                           ▼
maintainer (local):
  cargo release publish  ── push to crates.io
  cargo release tag      ── v3.1.5 locally
  cargo release push     ── push tag
                           │
                           ▼ (tag triggers)
GitHub Actions (auto):
  release.yml            ── 6-target build → GitHub Release → push Homebrew formula
                           │ (release published event)
                           ▼
  build.yml              ── download Release assets → patch package.json
                             → npm pack × 8 → npm publish (trusted publishing)
```

## Verification

- ✅ `actionlint .github/workflows/release-candidate.yml .github/workflows/build.yml` — zero errors
- ✅ All trusted-publishing bindings untouched (file name + job name + environment name preserved)
- ✅ npm `optionalDependencies` in `ccsp/package.json` get patched together with `version` so the root package's platform pins stay in lockstep

## Review checklist

- [ ] The trigger change (`on: release: published`) will intentionally **not** fire for pre-merge validation. A first dry run requires a real tag.
- [ ] `make bump` hard-failing is a breaking change for any local scripts that called it. Search for outside references (none known in this repo).
- [ ] `build.yml` relies on `gh release download` matching the exact archive names produced by cargo-dist 0.30.3 (`claude-code-statusline-pro-<target>.{tar.xz,zip}`). If the cargo-dist version is bumped, re-verify the filenames.

## Test plan

- [x] `actionlint` passes on both changed workflows
- [ ] Rust CI (`rust-ci.yml`) green on this PR
- [ ] (post-merge, before first release) Trigger `release-candidate.yml` from `main` — 6 build jobs all green
- [ ] (first release) `cargo release patch …` → candidate green → `cargo release publish/tag/push` → release.yml green → build.yml green → npm tarballs live