### PR TITLE
feat(widgets): add input widget type + Claude.ai rate-limit template

### DIFF
--- a/configs/components/usage.template.toml
+++ b/configs/components/usage.template.toml
@@ -440,6 +440,62 @@ data_path = "$.data.items[0]"          # 提取响应中数组的第一个元素
 # "User-Agent" = "claude-code-statusline-pro/2.3.0"
 
 # ====================================================================
+# Claude.ai 订阅 Rate Limits（官方 stdin payload，无需 API 请求）
+# ====================================================================
+# 适用于：Claude.ai Pro / Max 订阅用户
+# 数据源：Claude Code 注入 stdin 的 JSON 中的 rate_limits 字段
+# 检测方式：JSONPath 自动 gate；字段缺失时 widget 静默不渲染
+#
+# 使用步骤：
+# 1. 将本文件整体（或以下两段）复制到 ~/.claude/statusline-pro/components/usage.toml
+# 2. 主配置文件中确保 multiline.enabled = true
+# 3. 如需调整显示位置，修改 row（从 1 开始）和 col（从 0 开始）即可
+#
+# 本示例提供 2 个 widget：5 小时滚动窗口、7 天周窗口
+# 两个 widget 均放在第二行（row = 2），左右并排（col = 0, 1）
+
+[widgets.claude_rate_limit_5h]
+enabled = true
+type = "input"                # 🆕 从 Claude Code stdin payload 读取字段
+row = 2                       # 第二行
+col = 0                       # 最左列
+nerd_icon = "\uf2c8"          # clock 图标
+emoji_icon = "⏳"
+text_icon = "[5h]"
+# 模板字段说明：
+# - used_percentage: 百分比数字（0–100）
+# - resets_at: Unix epoch 秒；模板引擎自动识别秒/毫秒
+# - now(): 当前时间（毫秒，自动对齐）
+# - :.Hm 格式化为 "1小时23分钟"；其他选项见下
+template = "5h {used_percentage:.0f}% · 重置 {resets_at - now():.Hm}"
+
+# data_path: JSONPath 选中 rate_limits.five_hour 对象；
+# 若字段缺失（如非订阅用户或会话首次响应前）则 0 匹配，widget 不显示
+[widgets.claude_rate_limit_5h.api]
+data_path = "$.rate_limits.five_hour"
+
+[widgets.claude_rate_limit_7d]
+enabled = true
+type = "input"
+row = 2
+col = 1
+nerd_icon = "\uf073"          # calendar 图标
+emoji_icon = "📅"
+text_icon = "[7d]"
+template = "7d {used_percentage:.0f}% · 重置 {resets_at - now():.DHm}"
+
+[widgets.claude_rate_limit_7d.api]
+data_path = "$.rate_limits.seven_day"
+
+# 时间格式化选项备忘（与其他 widget 共享语法）：
+# {resets_at - now():.D}     → 天数（向上取整），例：3 天
+# {resets_at - now():.H}     → 小时数，例：51 小时
+# {resets_at - now():.m}     → 分钟数，例：3060 分钟
+# {resets_at - now():.Hm}    → 2小时15分钟
+# {resets_at - now():.DHm}   → 2天3小时15分钟
+# {resets_at - now():.HmS}   → 51小时15分钟30秒
+
+# ====================================================================
 # 配置说明和最佳实践
 # ====================================================================
 #

--- a/src/config/component_widgets.rs
+++ b/src/config/component_widgets.rs
@@ -27,6 +27,9 @@ pub enum WidgetType {
     #[default]
     Static,
     Api,
+    /// Reads fields directly from the Claude Code stdin payload
+    /// (e.g. `rate_limits`, `version`, `agent.name`).
+    Input,
 }
 
 /// Widget configuration

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -58,9 +58,42 @@ pub struct InputData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<CostInfo>,
 
+    /// Claude.ai subscription rate limits (Pro/Max only).
+    ///
+    /// Populated by Claude Code after the first API response in the session.
+    /// Contains usage percentages and reset timestamps for the 5-hour rolling
+    /// window and the 7-day weekly window. May be absent for non-subscribers
+    /// or before the first API call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limits: Option<RateLimitsInfo>,
+
     /// Additional fields for future expansion
     #[serde(flatten)]
     pub extra: Value,
+}
+
+/// Claude.ai subscription rate limits (Pro/Max only).
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct RateLimitsInfo {
+    /// 5-hour rolling window
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub five_hour: Option<RateLimitWindow>,
+
+    /// 7-day weekly window
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day: Option<RateLimitWindow>,
+}
+
+/// Per-window rate-limit state.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct RateLimitWindow {
+    /// Percentage of the window consumed, 0.0–100.0
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub used_percentage: Option<f64>,
+
+    /// Unix epoch **seconds** when the window resets
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at: Option<i64>,
 }
 
 /// Model information

--- a/src/core/multiline.rs
+++ b/src/core/multiline.rs
@@ -265,6 +265,7 @@ impl MultiLineRenderer {
                         None
                     }
                 },
+                WidgetType::Input => self.render_input_widget(widget_config, context),
             };
 
             if let Some(final_text) = widget_output {
@@ -359,6 +360,68 @@ impl MultiLineRenderer {
             &context.terminal,
             &self.config,
         )))
+    }
+
+    /// Render a widget whose data source is the Claude Code stdin payload.
+    ///
+    /// Unlike API widgets, this runs synchronously: no HTTP, no I/O. The
+    /// entire `InputData` is serialized to JSON so every stdin field becomes
+    /// addressable from templates (e.g. `{rate_limits.five_hour.used_percentage}`).
+    ///
+    /// Optional `widget.api.data_path` acts as a JSONPath-based gate:
+    /// if it resolves to zero matches, the widget is hidden instead of
+    /// rendering a template with missing placeholders.
+    fn render_input_widget(
+        &self,
+        widget: &WidgetConfig,
+        context: &RenderContext,
+    ) -> Option<String> {
+        let input_json = match serde_json::to_value(&*context.input) {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("[statusline] input widget serialize failed: {err}");
+                return None;
+            }
+        };
+
+        // data_path gate: if JSONPath yields zero matches, hide the widget.
+        // Reuses the `api.data_path` field to avoid introducing a new schema
+        // knob; only this field is read for input widgets (other api.* fields
+        // are ignored).
+        let selected =
+            if let Some(path) = widget.api.as_ref().and_then(|api| api.data_path.as_deref()) {
+                match jsonpath::select(&input_json, path) {
+                    Ok(matches) => match matches.first() {
+                        Some(value) => (*value).clone(),
+                        None => return None,
+                    },
+                    Err(err) => {
+                        eprintln!("[statusline] input widget JSONPath {path:?} error: {err}");
+                        return None;
+                    }
+                }
+            } else {
+                input_json.clone()
+            };
+
+        if !Self::passes_filter(widget, &input_json) {
+            return None;
+        }
+
+        let rendered_text = widget.template.as_deref().map_or_else(
+            || selected.to_string(),
+            |template| {
+                let template = substitute_env(template);
+                render_template(&template, &selected)
+            },
+        );
+
+        Some(Self::compose_with_icon(
+            widget,
+            &rendered_text,
+            &context.terminal,
+            &self.config,
+        ))
     }
 
     async fn fetch_api_data(&self, config: &WidgetApiConfig) -> Result<ApiData> {
@@ -1276,6 +1339,7 @@ fn f64_to_i64(value: f64) -> i64 {
 }
 
 #[cfg(test)]
+#[allow(clippy::literal_string_with_formatting_args)] // TOML test fixtures embed template syntax like {x:.0f}
 mod tests {
     use super::*;
     use crate::config::Config;
@@ -1408,6 +1472,122 @@ method = "GET"
 
         let rendered_percent = render_template("{quota / 500000:.2f%}", &data);
         assert_eq!(rendered_percent, "100.00%");
+    }
+
+    /// Helper: build a renderer + context for input-widget tests.
+    fn make_input_widget_test_case(
+        input: InputData,
+        widget_toml: &str,
+    ) -> TestResult<(
+        MultiLineRenderer,
+        RenderContext,
+        tempfile::TempDir, // keep alive for the duration of the test
+    )> {
+        let mut config = Config {
+            multiline: Some(MultilineConfig {
+                enabled: true,
+                max_rows: 5,
+                rows: HashMap::new(),
+            }),
+            ..Config::default()
+        };
+        config.components.order = vec!["usage".to_string()];
+
+        let temp_dir = tempfile::tempdir()?;
+        let component_path = temp_dir.path().join("components").join("usage.toml");
+        let component_dir = component_path
+            .parent()
+            .context("component path missing parent directory")?;
+        std::fs::create_dir_all(component_dir)?;
+        std::fs::write(&component_path, widget_toml)?;
+
+        let renderer = MultiLineRenderer::new(config.clone(), Some(temp_dir.path().to_path_buf()));
+        let context = RenderContext {
+            input: Arc::new(input),
+            config: Arc::new(config),
+            terminal: TerminalCapabilities {
+                color_support: ColorSupport::TrueColor,
+                supports_emoji: false,
+                supports_nerd_font: false,
+            },
+            preview_mode: false,
+        };
+        Ok((renderer, context, temp_dir))
+    }
+
+    #[tokio::test]
+    async fn test_input_widget_reads_rate_limits() -> TestResult {
+        use crate::core::input::{RateLimitWindow, RateLimitsInfo};
+
+        let input = InputData {
+            rate_limits: Some(RateLimitsInfo {
+                five_hour: Some(RateLimitWindow {
+                    used_percentage: Some(42.0),
+                    resets_at: Some(9_999_999_999),
+                }),
+                seven_day: None,
+            }),
+            ..InputData::default()
+        };
+
+        let (mut renderer, context, _temp_dir) = make_input_widget_test_case(
+            input,
+            r#"
+[widgets.rl5h]
+enabled = true
+type = "input"
+row = 2
+col = 0
+nerd_icon = ""
+emoji_icon = ""
+text_icon = ""
+template = "{used_percentage:.0f}%"
+
+[widgets.rl5h.api]
+data_path = "$.rate_limits.five_hour"
+"#,
+        )?;
+
+        let result = renderer.render_extension_lines(&context).await;
+        assert!(result.success, "render failed: {:?}", result.error);
+        assert_eq!(result.lines.len(), 1);
+        assert!(
+            result.lines[0].contains("42%"),
+            "expected 42% in line, got {:?}",
+            result.lines[0]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_input_widget_hides_when_field_missing() -> TestResult {
+        // InputData without rate_limits: JSONPath gate should skip the widget.
+        let (mut renderer, context, _temp_dir) = make_input_widget_test_case(
+            InputData::default(),
+            r#"
+[widgets.rl5h]
+enabled = true
+type = "input"
+row = 2
+col = 0
+nerd_icon = ""
+emoji_icon = ""
+text_icon = ""
+template = "{used_percentage:.0f}%"
+
+[widgets.rl5h.api]
+data_path = "$.rate_limits.five_hour"
+"#,
+        )?;
+
+        let result = renderer.render_extension_lines(&context).await;
+        assert!(result.success);
+        assert!(
+            result.lines.is_empty(),
+            "expected empty lines when rate_limits absent, got {:?}",
+            result.lines
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/core/multiline.rs
+++ b/src/core/multiline.rs
@@ -242,6 +242,7 @@ impl MultiLineRenderer {
             }
 
             let cache_key = format!("{component_name}::{widget_name}");
+            let allow_stale_cache = matches!(widget_config.kind, WidgetType::Api);
             let widget_output = match widget_config.kind {
                 WidgetType::Static => Some(self.render_static_widget(widget_config, context)),
                 WidgetType::Api => match self.render_api_widget(widget_config, context).await {
@@ -272,8 +273,15 @@ impl MultiLineRenderer {
                 self.grid
                     .set_cell(row, widget_config.col, final_text.clone());
                 self.widget_cache.insert(cache_key, final_text);
-            } else if let Some(previous) = self.widget_cache.get(&cache_key) {
-                self.grid.set_cell(row, widget_config.col, previous.clone());
+            } else {
+                if allow_stale_cache {
+                    if let Some(previous) = self.widget_cache.get(&cache_key) {
+                        self.grid.set_cell(row, widget_config.col, previous.clone());
+                        continue;
+                    }
+                }
+
+                self.widget_cache.remove(&cache_key);
             }
         }
 
@@ -1587,6 +1595,74 @@ data_path = "$.rate_limits.five_hour"
             "expected empty lines when rate_limits absent, got {:?}",
             result.lines
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_input_widget_does_not_reuse_stale_cache() -> TestResult {
+        use crate::core::input::{RateLimitWindow, RateLimitsInfo};
+
+        let widget_toml = r#"
+[widgets.rl5h]
+enabled = true
+type = "input"
+row = 2
+col = 0
+nerd_icon = ""
+emoji_icon = ""
+text_icon = ""
+template = "{used_percentage:.0f}%"
+
+[widgets.rl5h.api]
+data_path = "$.rate_limits.five_hour"
+"#;
+
+        let input_with_limits = InputData {
+            rate_limits: Some(RateLimitsInfo {
+                five_hour: Some(RateLimitWindow {
+                    used_percentage: Some(42.0),
+                    resets_at: Some(9_999_999_999),
+                }),
+                seven_day: None,
+            }),
+            ..InputData::default()
+        };
+
+        let (mut renderer, first_context, _temp_dir) =
+            make_input_widget_test_case(input_with_limits, widget_toml)?;
+
+        let first_result = renderer.render_extension_lines(&first_context).await;
+        assert!(
+            first_result.success,
+            "first render failed: {:?}",
+            first_result.error
+        );
+        assert_eq!(first_result.lines.len(), 1);
+        assert!(
+            first_result.lines[0].contains("42%"),
+            "expected 42% in first render, got {:?}",
+            first_result.lines[0]
+        );
+
+        let second_context = RenderContext {
+            input: Arc::new(InputData::default()),
+            config: first_context.config.clone(),
+            terminal: first_context.terminal,
+            preview_mode: first_context.preview_mode,
+        };
+
+        let second_result = renderer.render_extension_lines(&second_context).await;
+        assert!(
+            second_result.success,
+            "second render failed: {:?}",
+            second_result.error
+        );
+        assert!(
+            second_result.lines.is_empty(),
+            "expected stale input widget cache to stay hidden, got {:?}",
+            second_result.lines
+        );
+
         Ok(())
     }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -187,7 +187,7 @@ fn render_widget_help(frame: &mut Frame, area: Rect, app: &App) {
         Line::from("  ↑↓      上下选择"),
         Line::from("  n       新增(输入名字)"),
         Line::from("  Space   切 enabled"),
-        Line::from("  t       切 type (static ↔ api)"),
+        Line::from("  t       切 type (static → api → input)"),
         Line::from("  d/Del   删除(无二次确认)"),
         Line::from(""),
     ];

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -35,7 +35,7 @@ pub struct WidgetFile {
 pub struct WidgetEntry {
     pub name: String,
     pub enabled: bool,
-    pub kind: String, // "static" | "api"
+    pub kind: String, // "static" | "api" | "input"
     pub row: u32,
     pub col: u32,
 }
@@ -141,11 +141,16 @@ pub fn toggle_enabled(path: &Path, widget_name: &str) -> Result<bool> {
     Ok(!current)
 }
 
-/// 在 static ↔ api 之间循环。返回新类型字符串。
+/// 在 static → api → input → static 之间循环。返回新类型字符串。
 pub fn cycle_type(path: &Path, widget_name: &str) -> Result<String> {
     let mut doc = load_document(path)?;
     let current = widget_get_string(&doc, widget_name, "type").unwrap_or_else(|| "static".into());
-    let next = if current == "static" { "api" } else { "static" };
+    let next = match current.as_str() {
+        "static" => "api",
+        "api" => "input",
+        "input" => "static",
+        _ => "static",
+    };
     widget_set(&mut doc, widget_name, "type", toml_value(next))?;
     save_document(path, &doc)?;
     Ok(next.to_string())
@@ -441,6 +446,8 @@ content = "from user layer"
         let new_type = cycle_type(&path, "foo")?;
         assert_eq!(new_type, "api");
         let new_type = cycle_type(&path, "foo")?;
+        assert_eq!(new_type, "input");
+        let new_type = cycle_type(&path, "foo")?;
         assert_eq!(new_type, "static");
         Ok(())
     }
@@ -536,6 +543,36 @@ content = "from user layer"
         let path = write_inline_sample(temp.path())?;
         let new_type = cycle_type(&path, "foo")?;
         assert_eq!(new_type, "api");
+        let new_type = cycle_type(&path, "foo")?;
+        assert_eq!(new_type, "input");
+        let new_type = cycle_type(&path, "foo")?;
+        assert_eq!(new_type, "static");
+        Ok(())
+    }
+
+    #[test]
+    fn test_cycle_type_from_input_widget() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let comp_dir = temp.path().join("components");
+        fs::create_dir_all(&comp_dir)?;
+        let path = comp_dir.join("usage.toml");
+        fs::write(
+            &path,
+            r#"
+[widgets.rl5h]
+enabled = true
+type = "input"
+row = 2
+col = 0
+nerd_icon = ""
+emoji_icon = ""
+text_icon = ""
+template = "{used_percentage:.0f}%"
+"#,
+        )?;
+
+        let new_type = cycle_type(&path, "rl5h")?;
+        assert_eq!(new_type, "static");
         Ok(())
     }
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -116,6 +116,7 @@ fn parse_file(path: &Path) -> Option<WidgetFile> {
             kind: match cfg.kind {
                 claude_code_statusline_pro::config::WidgetType::Static => "static".to_string(),
                 claude_code_statusline_pro::config::WidgetType::Api => "api".to_string(),
+                claude_code_statusline_pro::config::WidgetType::Input => "input".to_string(),
             },
             row: cfg.row,
             col: cfg.col,


### PR DESCRIPTION
## Summary

- Add a third `WidgetType` (`input`) that renders from the Claude Code stdin payload synchronously — no HTTP, no env detection. This unlocks access to every official stdin field (`rate_limits`, `agent.name`, `version`, `output_style`, …) from pure-TOML widget definitions.
- Ship a ready-to-copy template for Claude.ai Pro/Max subscribers that surfaces the **5-hour rolling window** and **7-day weekly window** on the second statusline row, with reset countdowns.
- Add typed `InputData.rate_limits` (`RateLimitsInfo` / `RateLimitWindow`) matching the official schema.

## Why

Until now the widget system could only source data from static strings or HTTP APIs, which meant displaying Claude.ai subscription rate limits required a third-party proxy — even though Claude Code already injects `rate_limits.five_hour` / `rate_limits.seven_day` into every statusline invocation after the first API response. This PR closes that gap and, as a bonus, lets future contributors surface any other stdin field with zero Rust code.

## What changed

| File | Change |
|---|---|
| `src/config/component_widgets.rs` | `WidgetType::Input` variant |
| `src/core/input.rs` | Typed `rate_limits: Option<RateLimitsInfo>` field (extra `#[serde(flatten)]` still catches future additions) |
| `src/core/multiline.rs` | New `render_input_widget`: serializes `InputData` to JSON once, optionally applies `api.data_path` as a JSONPath gate (zero matches → widget hides instead of leaking `{placeholders}`), then reuses the existing template engine |
| `src/tui/widgets.rs` | Preview widget listing learns the new kind |
| `configs/components/usage.template.toml` | Appends `claude_rate_limit_5h` / `_7d` examples at `row=2`, plus time-format cheat sheet |

### Why existing utilities just work

`parse_numeric_timestamp` ([multiline.rs:1108](src/core/multiline.rs)) already auto-aligns Unix seconds vs. milliseconds (`< 1e12` → seconds → ×1000), so the official `resets_at` (epoch seconds) drops directly into time-diff formulas like `{resets_at - now():.DHm}` without manual unit conversion.

## Usage

```bash
cp configs/components/usage.template.toml ~/.claude/statusline-pro/components/usage.toml
# ensure multiline.enabled = true in main config
```

After the first API response, row 2 renders:

```
⏳ 5h 42% · 重置 1小时23分钟   📅 7d 37% · 重置 3天8小时15分钟
```

When `rate_limits` is absent (new session, non-subscriber), the widgets stay invisible — no placeholder leakage.

## Test plan

- [x] New unit tests: `test_input_widget_reads_rate_limits` (happy path) and `test_input_widget_hides_when_field_missing` (JSONPath gate)
- [x] `unset CLAUDECODE && make ci` passes end-to-end (fix → fmt → clippy-fix → clippy → check → test → build)
- [x] Manual smoke test: `echo '{"model":{"display_name":"Opus"},"workspace":{"current_dir":"/tmp"},"rate_limits":{"five_hour":{"used_percentage":23.5,"resets_at":9999999999},"seven_day":{"used_percentage":41.2,"resets_at":9999999999}}}' | ./target/release/claude-code-statusline-pro` → second row renders as expected
- [x] Manual negative test: same command without `rate_limits` → second row absent

## Reviewer notes

- **Pre-existing test flake unrelated to this PR**: running `make ci` inside a Claude Code session (where `CLAUDECODE=1` is set) combined with a user-level `effortLevel: xhigh` in `~/.claude/settings.json` causes 7 `components::model` tests to fail because model output gets the effort marker (`◉`) appended. This reproduces on `main` and is a test-isolation bug in `src/utils/effort.rs` resolution, not something introduced here. `unset CLAUDECODE && make ci` is green.
- **Schema-compat choice**: for `input` widgets the JSONPath gate reuses `[widgets.X.api].data_path` rather than introducing a top-level `data_path` field. This keeps the schema narrow and lets the filter/passes_filter code path be shared. Only `api.data_path` is read for input widgets; other `api.*` fields are ignored.
- **Placement**: examples are attached to the existing `usage` component's TOML (zero change to `components.order`). The semantic fit is "usage"; if you'd rather promote this to a dedicated `rate_limits` component in a follow-up, the generic `input` type is already in place.