### PR TITLE
[codex] Honor third-party model context windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ show_progress_bar = true     # 显示进度条
 show_percentage = true       # 显示百分比
 progress_width = 15          # 进度条宽度
 
+# 模型上下文窗口覆盖（内置已包含常见国产/第三方模型）
+# 精确 key 优先于通配前缀；命中模型专属窗口时会覆盖 Claude Code stdin 的通用 200K。
+[components.tokens.context_windows]
+"deepseek-v4-*" = 1_000_000
+"qwen-long*" = 10_000_000
+"my-provider/my-model" = 500_000
+
 # Token阈值配置
 [components.tokens.thresholds]
 warning = 60    # 60%显示黄色警告
@@ -752,6 +759,13 @@ show_gradient = true         # Enable colored gradient progress bar
 show_progress_bar = true     # Show progress bar
 show_percentage = true       # Show percentage
 progress_width = 15          # Progress bar width
+
+# Model context window overrides (common CN/third-party models are built in)
+# Exact keys win over wildcard prefixes; model-specific hits override Claude Code's generic 200K stdin value.
+[components.tokens.context_windows]
+"deepseek-v4-*" = 1_000_000
+"qwen-long*" = 10_000_000
+"my-provider/my-model" = 500_000
 
 # Token threshold configuration
 [components.tokens.thresholds]

--- a/configs/config.template.toml
+++ b/configs/config.template.toml
@@ -349,6 +349,9 @@ critical = "[X]"
 
 # 上下文窗口大小映射 | Context window size mapping
 # 为不同模型定义上下文窗口大小（Token数）
+# 内置已包含常见 Claude、DeepSeek、Qwen、Kimi、MiniMax、MiMo、豆包、混元、GLM 模型。
+# 这里可以覆盖或补充模型窗口；精确 key 优先于带 * 的前缀匹配。
+# 命中模型专属窗口时，会覆盖 Claude Code stdin 中常见的 200K 通用窗口。
 [components.tokens.context_windows]
 default = 200_000                          # 默认窗口大小
 "claude-opus-4-1-20250805" = 200_000
@@ -358,6 +361,10 @@ default = 200_000                          # 默认窗口大小
 "claude-3-7-sonnet-20250219" = 200_000
 "claude-3-5-haiku-20241022" = 200_000
 "claude-3-haiku-20240307" = 200_000
+# 示例：第三方模型或自定义路由
+"deepseek-v4-*" = 1_000_000
+"qwen-long*" = 10_000_000
+"my-provider/my-model" = 500_000
 
 # -------------------- Usage组件 --------------------
 # 显示会话成本和代码行数统计

--- a/src/components/tokens.rs
+++ b/src/components/tokens.rs
@@ -75,11 +75,20 @@ impl TokensComponent {
             return None;
         }
 
-        let total = context_window
+        let official_total = context_window
             .get("context_window_size")
             .or_else(|| context_window.get("contextWindowSize"))
-            .and_then(serde_json::Value::as_u64)
+            .and_then(serde_json::Value::as_u64);
+        let model_total = self.model_specific_context_window(ctx);
+        let total = model_total
+            .or(official_total)
             .unwrap_or_else(|| self.context_window_for_model(ctx));
+        let percentage =
+            if model_total.is_some_and(|window| Some(window) != official_total) && used > 0 {
+                None
+            } else {
+                percentage
+            };
 
         Some(TokenUsageInfo {
             used,
@@ -150,32 +159,36 @@ impl TokensComponent {
     }
 
     fn context_window_for_model(&self, ctx: &RenderContext) -> u64 {
-        let default_window = self
-            .config
+        self.model_specific_context_window(ctx)
+            .unwrap_or_else(|| self.default_context_window())
+    }
+
+    fn default_context_window(&self) -> u64 {
+        self.config
             .context_windows
             .get("default")
             .copied()
-            .unwrap_or(200_000);
+            .unwrap_or(200_000)
+    }
 
-        let Some(model) = ctx.input.model.as_ref() else {
-            return default_window;
-        };
+    fn model_specific_context_window(&self, ctx: &RenderContext) -> Option<u64> {
+        let model = ctx.input.model.as_ref()?;
 
         if let Some(id) = model.id.as_ref() {
             // Priority 1: Exact match from config
-            if let Some(value) = self.config.context_windows.get(id) {
-                return *value;
+            if let Some(value) = context_window_from_map(&self.config.context_windows, id) {
+                return Some(value);
             }
 
             // Priority 2: Infer from model ID params (e.g., [1m])
             if let Some(parsed) = parse_model_id(id) {
                 if let Some(window) = parsed.infer_context_window() {
-                    return window;
+                    return Some(window);
                 }
             }
         }
 
-        default_window
+        None
     }
 
     fn build_progress_bar(&self, ctx: &RenderContext, percentage: f64) -> Option<String> {
@@ -393,6 +406,66 @@ impl Component for TokensComponent {
     fn base_config(&self, _ctx: &RenderContext) -> Option<&BaseComponentConfig> {
         Some(&self.config.base)
     }
+}
+
+fn context_window_from_map(
+    context_windows: &std::collections::HashMap<String, u64>,
+    model_id: &str,
+) -> Option<u64> {
+    let candidates = model_id_candidates(model_id);
+
+    for candidate in &candidates {
+        if let Some(value) = find_exact_context_window(context_windows, candidate) {
+            return Some(value);
+        }
+    }
+
+    find_prefix_context_window(context_windows, &candidates)
+}
+
+fn find_exact_context_window(
+    context_windows: &std::collections::HashMap<String, u64>,
+    candidate: &str,
+) -> Option<u64> {
+    context_windows
+        .iter()
+        .find(|(key, _)| {
+            !key.eq_ignore_ascii_case("default")
+                && !key.ends_with('*')
+                && key.eq_ignore_ascii_case(candidate)
+        })
+        .map(|(_, value)| *value)
+}
+
+fn find_prefix_context_window(
+    context_windows: &std::collections::HashMap<String, u64>,
+    candidates: &[String],
+) -> Option<u64> {
+    context_windows
+        .iter()
+        .filter_map(|(key, value)| {
+            let prefix = key.strip_suffix('*')?;
+            if prefix.eq_ignore_ascii_case("default") {
+                return None;
+            }
+            candidates
+                .iter()
+                .any(|candidate| candidate.starts_with(&prefix.to_ascii_lowercase()))
+                .then_some((prefix.len(), *value))
+        })
+        .max_by_key(|(len, _)| *len)
+        .map(|(_, value)| value)
+}
+
+fn model_id_candidates(model_id: &str) -> Vec<String> {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    let mut candidates = vec![normalized.clone()];
+
+    if let Some((_, last)) = normalized.rsplit_once('/') {
+        candidates.push(last.to_string());
+    }
+
+    candidates
 }
 
 fn icon_for_kind(set: &crate::config::TokenIconSetConfig, kind: TokenStatusKind) -> Option<&str> {
@@ -717,6 +790,137 @@ mod tests {
 
         assert!(output.visible);
         assert!(output.text.contains("(1075/200000)"));
+    }
+
+    #[tokio::test]
+    async fn test_tokens_builtin_model_window_overrides_generic_official_input() {
+        use crate::core::ModelInfo;
+
+        let input = build_input(|input| {
+            input.session_id = Some("deepseek-session".to_string());
+            input.model = Some(ModelInfo {
+                id: Some("deepseek-v4-pro".to_string()),
+                display_name: None,
+            });
+            input.extra = json!({
+                "context_window": {
+                    "context_window_size": 200_000u64,
+                    "used_percentage": 26.75f64,
+                    "current_usage": {
+                        "input_tokens": 53_500u64,
+                        "cache_creation_input_tokens": 0u64,
+                        "cache_read_input_tokens": 0u64
+                    }
+                }
+            });
+        });
+
+        let ctx = RenderContext {
+            input: Arc::new(input),
+            config: Arc::new(Config::default()),
+            terminal: TerminalCapabilities::default(),
+            preview_mode: false,
+        };
+
+        let config = build_tokens_config(|config| {
+            config.show_progress_bar = false;
+            config.show_percentage = true;
+            config.show_raw_numbers = true;
+        });
+
+        let component = TokensComponent::new(config);
+        let output = component.render(&ctx).await;
+
+        assert!(output.visible);
+        assert!(output.text.contains("5.3%"));
+        assert!(output.text.contains("(53500/1000000)"));
+    }
+
+    #[tokio::test]
+    async fn test_tokens_user_exact_context_window_overrides_builtin_prefix() {
+        use crate::core::ModelInfo;
+
+        let input = build_input(|input| {
+            input.session_id = Some("deepseek-session".to_string());
+            input.model = Some(ModelInfo {
+                id: Some("deepseek-v4-pro".to_string()),
+                display_name: None,
+            });
+            input.extra = json!({
+                "context_window": {
+                    "context_window_size": 200_000u64,
+                    "current_usage": {
+                        "input_tokens": 10_000u64,
+                        "cache_creation_input_tokens": 0u64,
+                        "cache_read_input_tokens": 0u64
+                    }
+                }
+            });
+        });
+
+        let ctx = RenderContext {
+            input: Arc::new(input),
+            config: Arc::new(Config::default()),
+            terminal: TerminalCapabilities::default(),
+            preview_mode: false,
+        };
+
+        let config = build_tokens_config(|config| {
+            config.show_progress_bar = false;
+            config.show_percentage = false;
+            config.show_raw_numbers = true;
+            config
+                .context_windows
+                .insert("deepseek-v4-pro".to_string(), 777_000);
+        });
+
+        let component = TokensComponent::new(config);
+        let output = component.render(&ctx).await;
+
+        assert!(output.visible);
+        assert!(output.text.contains("(10000/777000)"));
+    }
+
+    #[tokio::test]
+    async fn test_tokens_namespaced_model_id_uses_builtin_context_window() {
+        use crate::core::ModelInfo;
+
+        let input = build_input(|input| {
+            input.session_id = Some("mimo-session".to_string());
+            input.model = Some(ModelInfo {
+                id: Some("xiaomi/mimo-v2.5-pro".to_string()),
+                display_name: None,
+            });
+            input.extra = json!({
+                "context_window": {
+                    "context_window_size": 200_000u64,
+                    "current_usage": {
+                        "input_tokens": 10_000u64,
+                        "cache_creation_input_tokens": 0u64,
+                        "cache_read_input_tokens": 0u64
+                    }
+                }
+            });
+        });
+
+        let ctx = RenderContext {
+            input: Arc::new(input),
+            config: Arc::new(Config::default()),
+            terminal: TerminalCapabilities::default(),
+            preview_mode: false,
+        };
+
+        let config = build_tokens_config(|config| {
+            config.show_progress_bar = false;
+            config.show_percentage = false;
+            config.show_raw_numbers = true;
+        });
+
+        let component = TokensComponent::new(config);
+        let output = component.render(&ctx).await;
+
+        assert!(output.visible);
+        assert!(output.text.contains("(10000/1000000)"));
     }
 
     #[tokio::test]

--- a/src/components/tokens.rs
+++ b/src/components/tokens.rs
@@ -448,20 +448,51 @@ fn find_prefix_context_window(
     context_windows: &std::collections::HashMap<String, u64>,
     candidates: &[String],
 ) -> Option<u64> {
-    context_windows
-        .iter()
-        .filter_map(|(key, value)| {
-            let prefix = key.strip_suffix('*')?;
-            if prefix.eq_ignore_ascii_case("default") {
-                return None;
+    let mut best: Option<PrefixContextMatch<'_>> = None;
+
+    for (key, value) in context_windows {
+        let Some(prefix) = key.strip_suffix('*') else {
+            continue;
+        };
+        if prefix.eq_ignore_ascii_case("default") {
+            continue;
+        }
+
+        let normalized_prefix = prefix.to_ascii_lowercase();
+        if let Some(candidate_index) = candidates
+            .iter()
+            .position(|candidate| candidate.starts_with(&normalized_prefix))
+        {
+            let candidate_match = PrefixContextMatch {
+                candidate_index,
+                prefix_len: normalized_prefix.len(),
+                key,
+                value: *value,
+            };
+            if best.is_none_or(|current| candidate_match.is_better_than(current)) {
+                best = Some(candidate_match);
             }
-            candidates
-                .iter()
-                .any(|candidate| candidate.starts_with(&prefix.to_ascii_lowercase()))
-                .then_some((prefix.len(), *value))
-        })
-        .max_by_key(|(len, _)| *len)
-        .map(|(_, value)| value)
+        }
+    }
+
+    best.map(|candidate_match| candidate_match.value)
+}
+
+#[derive(Clone, Copy)]
+struct PrefixContextMatch<'a> {
+    candidate_index: usize,
+    prefix_len: usize,
+    key: &'a str,
+    value: u64,
+}
+
+impl PrefixContextMatch<'_> {
+    fn is_better_than(self, other: Self) -> bool {
+        self.candidate_index < other.candidate_index
+            || (self.candidate_index == other.candidate_index
+                && (self.prefix_len > other.prefix_len
+                    || (self.prefix_len == other.prefix_len && self.key < other.key)))
+    }
 }
 
 fn model_id_candidates(model_id: &str) -> Vec<String> {
@@ -971,6 +1002,28 @@ mod tests {
 
         assert!(output.visible);
         assert!(output.text.contains("(10000/1000000)"));
+    }
+
+    #[test]
+    fn test_prefix_context_window_prefers_full_model_candidate_over_stripped_alias() {
+        let mut context_windows = std::collections::HashMap::new();
+        context_windows.insert("acme/*".to_string(), 777_000);
+        context_windows.insert("mimo-*".to_string(), 1_000_000);
+
+        let window = context_window_from_map(&context_windows, "acme/mimo-v2-pro");
+
+        assert_eq!(window, Some(777_000));
+    }
+
+    #[test]
+    fn test_prefix_context_window_prefers_longer_prefix_for_same_candidate() {
+        let mut context_windows = std::collections::HashMap::new();
+        context_windows.insert("qwen3-*".to_string(), 262_144);
+        context_windows.insert("qwen3-coder-*".to_string(), 1_000_000);
+
+        let window = context_window_from_map(&context_windows, "qwen3-coder-plus");
+
+        assert_eq!(window, Some(1_000_000));
     }
 
     #[tokio::test]

--- a/src/components/tokens.rs
+++ b/src/components/tokens.rs
@@ -80,15 +80,22 @@ impl TokensComponent {
             .or_else(|| context_window.get("contextWindowSize"))
             .and_then(serde_json::Value::as_u64);
         let model_total = self.model_specific_context_window(ctx);
-        let total = model_total
-            .or(official_total)
-            .unwrap_or_else(|| self.context_window_for_model(ctx));
-        let percentage =
-            if model_total.is_some_and(|window| Some(window) != official_total) && used > 0 {
-                None
-            } else {
-                percentage
-            };
+        let should_override_official_total = matches!(
+            (official_total, model_total),
+            (Some(200_000), Some(model_window)) if model_window != 200_000
+        );
+        let total = if should_override_official_total {
+            model_total.unwrap_or(200_000)
+        } else {
+            official_total
+                .or(model_total)
+                .unwrap_or_else(|| self.context_window_for_model(ctx))
+        };
+        let percentage = if should_override_official_total && used > 0 {
+            None
+        } else {
+            percentage
+        };
 
         Some(TokenUsageInfo {
             used,
@@ -834,6 +841,49 @@ mod tests {
         assert!(output.visible);
         assert!(output.text.contains("5.3%"));
         assert!(output.text.contains("(53500/1000000)"));
+    }
+
+    #[tokio::test]
+    async fn test_tokens_specific_official_context_window_overrides_builtin_model_window() {
+        use crate::core::ModelInfo;
+
+        let input = build_input(|input| {
+            input.session_id = Some("deepseek-session".to_string());
+            input.model = Some(ModelInfo {
+                id: Some("deepseek-v4-pro".to_string()),
+                display_name: None,
+            });
+            input.extra = json!({
+                "context_window": {
+                    "context_window_size": 1_048_576u64,
+                    "used_percentage": 5.1f64,
+                    "current_usage": {
+                        "input_tokens": 53_500u64,
+                        "cache_creation_input_tokens": 0u64,
+                        "cache_read_input_tokens": 0u64
+                    }
+                }
+            });
+        });
+
+        let ctx = RenderContext {
+            input: Arc::new(input),
+            config: Arc::new(Config::default()),
+            terminal: TerminalCapabilities::default(),
+            preview_mode: false,
+        };
+
+        let config = build_tokens_config(|config| {
+            config.show_progress_bar = false;
+            config.show_percentage = false;
+            config.show_raw_numbers = true;
+        });
+
+        let component = TokensComponent::new(config);
+        let output = component.render(&ctx).await;
+
+        assert!(output.visible);
+        assert!(output.text.contains("(53500/1048576)"));
     }
 
     #[tokio::test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1162,7 +1162,99 @@ const fn default_critical_threshold() -> f64 {
 fn default_context_windows() -> HashMap<String, u64> {
     let mut map = HashMap::new();
     map.insert("default".to_string(), 200_000);
+    insert_context_windows(
+        &mut map,
+        &[
+            // Claude / Anthropic
+            ("claude-opus-4-1-20250805", 200_000),
+            ("claude-opus-4-20250514", 200_000),
+            ("claude-sonnet-4-20250514", 200_000),
+            ("claude-sonnet-4-20250514[1m]", 1_000_000),
+            ("claude-3-7-sonnet-20250219", 200_000),
+            ("claude-3-5-haiku-20241022", 200_000),
+            ("claude-3-haiku-20240307", 200_000),
+            // DeepSeek
+            ("deepseek-v4-*", 1_000_000),
+            ("deepseek-chat", 1_000_000),
+            ("deepseek-reasoner", 1_000_000),
+            ("deepseek-v3.1*", 131_072),
+            ("deepseek-chat-v3.1*", 131_072),
+            ("deepseek-v3-0324", 65_536),
+            ("deepseek-chat-v3-0324", 65_536),
+            ("deepseek-r1*", 65_536),
+            // Qwen / Alibaba Model Studio
+            ("qwen3.6-plus*", 1_000_000),
+            ("qwen-plus*", 995_904),
+            ("qwen-turbo*", 1_000_000),
+            ("qwen-max*", 32_768),
+            ("qwen3-max*", 262_144),
+            ("qwen-long*", 10_000_000),
+            ("qwen3-coder-plus*", 1_000_000),
+            ("qwen3-coder-flash*", 1_000_000),
+            ("qwen3-coder-next*", 262_144),
+            ("qwen3-coder-480b-a35b-instruct", 262_144),
+            ("qwen3-coder-30b-a3b-instruct", 262_144),
+            // Moonshot / Kimi
+            ("kimi-k2.6*", 262_144),
+            ("kimi-k2.5*", 262_144),
+            ("kimi-k2-0905*", 262_144),
+            ("kimi-k2-turbo*", 262_144),
+            ("kimi-k2-thinking*", 262_144),
+            ("kimi-k2-0711*", 131_072),
+            ("moonshot-v1-8k*", 8_192),
+            ("moonshot-v1-32k*", 32_768),
+            ("moonshot-v1-128k*", 131_072),
+            // MiniMax
+            ("minimax-m2*", 204_800),
+            ("minimax-m1*", 1_000_000),
+            ("minimax-text-01", 4_000_000),
+            ("minimax-01", 4_000_000),
+            ("abab6.5*", 200_000),
+            // Xiaomi MiMo
+            ("mimo-v2-flash*", 262_144),
+            ("mimo-v2-pro*", 1_000_000),
+            ("mimo-v2.5*", 1_000_000),
+            ("mimo-v2.5-pro*", 1_000_000),
+            // Doubao / Volcengine Ark
+            ("doubao-seed-1.6*", 262_144),
+            ("seed-1.6*", 262_144),
+            ("doubao-seed-code*", 262_144),
+            ("doubao-1.5-pro-32k", 32_768),
+            ("doubao-1.5-pro-256k", 262_144),
+            ("doubao-pro-32k", 32_768),
+            ("doubao-pro-128k", 131_072),
+            ("doubao-pro-256k", 262_144),
+            // Tencent Hunyuan
+            ("hunyuan-turbos-latest", 32_768),
+            ("hunyuan-large", 28_672),
+            ("hunyuan-large-longcontext", 131_072),
+            ("hunyuan-lite", 262_144),
+            ("hunyuan-standard", 30_720),
+            ("hunyuan-standard-256k", 256_000),
+            ("hunyuan-a13b", 262_144),
+            // Zhipu / Z.ai GLM
+            ("glm-5.1*", 202_745),
+            ("glm-5*", 202_752),
+            ("glm-4.7*", 169_984),
+            ("glm-4.6*", 200_000),
+            ("glm-4.5*", 131_072),
+            ("glm-4-plus", 131_072),
+            ("glm-4-air-250414", 131_072),
+            ("glm-4-airx", 8_192),
+            ("glm-4-flashx-250414", 131_072),
+            ("glm-4-flash-250414", 131_072),
+            ("glm-z1-air", 131_072),
+            ("glm-z1-airx", 32_768),
+            ("glm-z1-flash*", 131_072),
+        ],
+    );
     map
+}
+
+fn insert_context_windows(map: &mut HashMap<String, u64>, entries: &[(&str, u64)]) {
+    for (model, window) in entries {
+        map.insert((*model).to_string(), *window);
+    }
 }
 
 fn default_emoji_icon_set() -> TokenIconSetConfig {


### PR DESCRIPTION
## Summary
- Add built-in context window mappings for common third-party and Chinese LLM providers, including DeepSeek, Qwen, Kimi/Moonshot, MiniMax, MiMo, Doubao, Hunyuan, and GLM.
- Allow exact and wildcard-prefix `components.tokens.context_windows` matches, including namespaced model IDs such as `provider/model`.
- Prefer model-specific context windows over Claude Code's generic stdin `200K` value and recompute percentages when the window is overridden.

## Root Cause
Claude Code can pass a generic `context_window_size` of `200000` for models routed through `ANTHROPIC_BASE_URL`, so existing user or model-specific context settings were ignored whenever that stdin field was present.

## Validation
- `make ci`
- Manual CLI check: `deepseek-v4-pro` with stdin `context_window_size: 200000` now renders `5.3% (53500/1000000)`.

Closes #63