### PR TITLE
fix: resolve builtin pricing for model ids with bracket suffix

### DIFF
--- a/src/components/usage.rs
+++ b/src/components/usage.rs
@@ -791,4 +791,30 @@ mod tests {
 
         assert!((cost - 1.23).abs() < 1e-9);
     }
+
+    #[test]
+    fn deepseek_1m_suffix_recalculates_instead_of_passing_through_upstream() {
+        // 回归 issue #75:模型名带 [1m] 后缀时,旧逻辑因 pricing 匹配失败而把上游
+        // 虚高的 total_cost_usd(16.54)原样透传;修复后应使用内置 deepseek 价重算。
+        let data = serde_json::json!({
+            "model": { "id": "deepseek-v4-pro[1m]" },
+            "cost": {
+                "total_cost_usd": 16.54,
+                "input_tokens": 793_900,
+                "output_tokens": 129_600,
+                "cache_read_tokens": 18_700_000
+            }
+        });
+        let ctx = RenderContext {
+            input: std::sync::Arc::new(InputData::default()),
+            config: std::sync::Arc::new(Config::default()),
+            terminal: TerminalCapabilities::default(),
+            preview_mode: false,
+        };
+
+        let cost = UsageComponent::resolve_display_cost(&data, None, &ctx);
+
+        // 793.9k×3 + 129.6k×6 + 18.7M×0.025 = 3,626,800 / 1_000_000 = 3.6268
+        assert!((cost - 3.6268).abs() < 1e-6, "expected ~3.6268, got {cost}");
+    }
 }

--- a/src/utils/provider_profiles.rs
+++ b/src/utils/provider_profiles.rs
@@ -1117,11 +1117,29 @@ fn model_id_candidates(model_id: &str) -> Vec<String> {
     let normalized = model_id.trim().to_ascii_lowercase();
     let mut candidates = vec![normalized.clone()];
 
+    // 形如 `deepseek-v4-pro[1m]` 的参数后缀会让精确 pricing / context key 匹配失败,
+    // 追加一个剥离 `[...]` 后缀的候选,使其回落到基础模型名再匹配一次。
+    if let Some(base) = strip_param_suffix(&normalized) {
+        candidates.push(base.to_string());
+    }
+
     if let Some((_, last)) = normalized.rsplit_once('/') {
         candidates.push(last.to_string());
+        if let Some(base) = strip_param_suffix(last) {
+            candidates.push(base.to_string());
+        }
     }
 
     candidates
+}
+
+/// Strip a trailing parameter suffix such as `[1m]` from a model id, returning the
+/// base name. Returns `None` when there is no suffix or the base would be empty.
+fn strip_param_suffix(model: &str) -> Option<&str> {
+    model
+        .split_once('[')
+        .map(|(base, _)| base.trim_end())
+        .filter(|base| !base.is_empty())
 }
 
 fn model_candidates(model_names: &[String]) -> Vec<String> {
@@ -1192,6 +1210,45 @@ fn model_pattern_matches(pattern: &str, model_name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_param_suffix_extracts_base_model_name() {
+        assert_eq!(
+            strip_param_suffix("deepseek-v4-pro[1m]"),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(strip_param_suffix("deepseek-v4-pro"), None);
+        assert_eq!(strip_param_suffix("[1m]"), None);
+    }
+
+    #[test]
+    fn deepseek_1m_suffix_resolves_builtin_pricing() {
+        let providers = default_model_providers();
+
+        // deepseek-v4-pro 的内置 pricing:input 3 / output 6 / cache_read 0.025
+        let is_v4_pro_pricing = |pricing: &ModelPricingConfig| {
+            (pricing.input - 3.0).abs() < 1e-9
+                && (pricing.output - 6.0).abs() < 1e-9
+                && pricing.cache_read.is_some_and(|v| (v - 0.025).abs() < 1e-9)
+        };
+
+        // 不带后缀:命中内置 pricing
+        assert!(
+            provider_pricing(&providers, &["deepseek-v4-pro".to_string()], None)
+                .as_ref()
+                .is_some_and(&is_v4_pro_pricing),
+            "plain deepseek-v4-pro should resolve builtin pricing"
+        );
+
+        // 回归 issue #75:带 [1m] 后缀的模型名剥离后缀后回落到同一条内置 pricing,
+        // 不再因匹配失败而 fallback 到上游虚高 cost。
+        assert!(
+            provider_pricing(&providers, &["deepseek-v4-pro[1m]".to_string()], None)
+                .as_ref()
+                .is_some_and(&is_v4_pro_pricing),
+            "deepseek-v4-pro[1m] should resolve builtin pricing after stripping [1m]"
+        );
+    }
 
     #[test]
     fn prefix_context_window_prefers_full_model_candidate_over_stripped_alias() {


### PR DESCRIPTION
## 问题(issue #75)

状态栏对 DeepSeek 计价虚高:`deepseek-v4-pro[1m]` 显示约 ¥16.54,而按内置/官网价格实际应为 ¥3.63。

issue 中 Gemini 归因为「cache_read 套用了 input 单价」,但该归因不成立:
- `calculate_priced_cost` 使用独立的 `pricing.cache_read`,内置 `deepseek-v4-pro` 已配 `cache_read = 0.025`,不会回退到 input 价;
- 按其给出的 token 数(793.9k / 129.6k / 18.7M)+ 内置价算出的正是 ¥3.63,而非 16.54,归因自相矛盾。

## 根因

带 `[1m]` 参数后缀的模型名在 **pricing 匹配路径**上会失败:
- `model_id_candidates` 只剥离 `/` 前缀,不剥离 `[...]` 后缀;
- 内置 pricing 表只有精确 key(`deepseek-v4-pro`),没有通配 key;
- 于是 `provider_pricing` 返回 `None` → `resolve_display_cost` 回退,直接透传 Claude Code 上游的 `total_cost_usd`(对第三方 DeepSeek 往往严重虚高)。

> context window 路径不受影响——它有 `deepseek-v4-*` 通配 key 及 model_parser 兜底,所以同一个 `[1m]` 在 context 能解析、在 pricing 却 miss,两条路径对参数后缀处理不一致。这正是缺陷根源。

## 修复

`model_id_candidates` 追加一个剥离 `[...]` 后缀的候选,使带后缀的模型名回落到基础名命中精确 pricing / context key,统一两条路径的处理。

## 验证

- `strip_param_suffix_extracts_base_model_name`
- `deepseek_1m_suffix_resolves_builtin_pricing`:`deepseek-v4-pro[1m]` 解析到内置 pricing(3 / 6 / 0.025)
- `deepseek_1m_suffix_recalculates_instead_of_passing_through_upstream`:复现 issue 场景,上游 16.54 被内置价重算为 3.6268
- `make ci` 全绿(clippy 严格 + 220 测试)

## 官网价格核对

| 型号 | 官网 CNY(命中/未命中/输出) | 内置 pricing |
|---|---|---|
| deepseek-v4-pro | 0.025 / 3 / 6 | 0.025 / 3 / 6 ✅ |
| deepseek-v4-flash | 0.02 / 1 / 2 | 0.02 / 1 / 2 ✅ |

内置价格与官网完全一致,无需调整。

Closes #75
